### PR TITLE
Add expression cursor with tap-to-position

### DIFF
--- a/app/src/main/java/com/m3calculator/CalculatorScreen.kt
+++ b/app/src/main/java/com/m3calculator/CalculatorScreen.kt
@@ -11,6 +11,8 @@ import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.items
 import androidx.compose.foundation.shape.CircleShape
 import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.foundation.gestures.detectTapGestures
+import androidx.compose.ui.input.pointer.pointerInput
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.filled.AccessTime
 import androidx.compose.material.icons.filled.DeleteOutline
@@ -21,6 +23,8 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
 import androidx.compose.ui.graphics.graphicsLayer
 import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.platform.LocalDensity
+import androidx.compose.ui.unit.IntOffset
 import androidx.compose.ui.hapticfeedback.HapticFeedbackType
 import androidx.compose.ui.platform.LocalHapticFeedback
 import androidx.compose.ui.text.font.FontWeight
@@ -120,6 +124,8 @@ fun CalculatorScreen(viewModel: CalculatorViewModel) {
             // Display area
             DisplaySection(
                 expression = viewModel.expression,
+                cursorPosition = viewModel.cursorPosition,
+                onCursorChange = { viewModel.moveCursorTo(it) },
                 result = viewModel.result,
                 history = viewModel.history,
                 modifier = Modifier
@@ -191,11 +197,16 @@ fun CalculatorScreen(viewModel: CalculatorViewModel) {
 @Composable
 fun DisplaySection(
     expression: String,
+    cursorPosition: Int,
+    onCursorChange: (Int) -> Unit,
     result: String,
     history: String,
     modifier: Modifier = Modifier
 ) {
     val colorScheme = MaterialTheme.colorScheme
+
+    val formatted = formatExpression(expression)
+    val cursorInFormatted = mapCursorToFormatted(expression, cursorPosition)
 
     Column(
         modifier = modifier,
@@ -236,18 +247,72 @@ fun DisplaySection(
             label = "fontSize"
         )
 
-        Text(
-            text = formatExpression(expression).ifEmpty { "0" },
-            fontSize = animatedFontSize.sp,
-            fontWeight = FontWeight.Light,
-            color = if (expression.isEmpty()) colorScheme.outlineVariant else colorScheme.onSurface,
-            textAlign = TextAlign.End,
-            maxLines = 2,
-            overflow = TextOverflow.Ellipsis,
-            lineHeight = (animatedFontSize * 1.15).sp,
-            modifier = Modifier.fillMaxWidth(),
-            letterSpacing = (-0.5).sp
-        )
+        val displayText = formatted.ifEmpty { "0" }
+        val cursorVisible = cursorPosition < expression.length && expression.isNotEmpty()
+
+        val textLayoutResult = remember { mutableStateOf<androidx.compose.ui.text.TextLayoutResult?>(null) }
+        val blinkVisible = if (cursorVisible) {
+            val infiniteTransition = rememberInfiniteTransition(label = "cursorBlink")
+            val alpha by infiniteTransition.animateFloat(
+                initialValue = 1f,
+                targetValue = 0f,
+                animationSpec = infiniteRepeatable(
+                    animation = keyframes {
+                        durationMillis = 1000
+                        1f at 0
+                        1f at 500
+                        0f at 501
+                        0f at 1000
+                    },
+                    repeatMode = RepeatMode.Restart
+                ),
+                label = "cursorAlpha"
+            )
+            alpha > 0.5f
+        } else false
+
+        Box(modifier = Modifier.fillMaxWidth()) {
+            Text(
+                text = displayText,
+                fontSize = animatedFontSize.sp,
+                fontWeight = FontWeight.Light,
+                color = if (expression.isEmpty()) colorScheme.outlineVariant else colorScheme.onSurface,
+                textAlign = TextAlign.End,
+                maxLines = 2,
+                overflow = TextOverflow.Ellipsis,
+                lineHeight = (animatedFontSize * 1.15).sp,
+                letterSpacing = (-0.5).sp,
+                onTextLayout = { textLayoutResult.value = it },
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .pointerInput(displayText) {
+                        detectTapGestures { offset ->
+                            textLayoutResult.value?.let { layout ->
+                                val tappedOffset = layout.getOffsetForPosition(offset)
+                                val rawCursor = mapCursorFromFormatted(expression, tappedOffset)
+                                onCursorChange(rawCursor)
+                            }
+                        }
+                    }
+            )
+
+            if (cursorVisible && blinkVisible) {
+                textLayoutResult.value?.let { layout ->
+                    val cursorOffset = cursorInFormatted.coerceAtMost(displayText.length)
+                    val cursorRect = layout.getCursorRect(cursorOffset)
+                    Box(
+                        modifier = Modifier
+                            .offset(
+                                x = with(LocalDensity.current) { cursorRect.left.toDp() },
+                                y = with(LocalDensity.current) { cursorRect.top.toDp() }
+                            )
+                            .width(2.dp)
+                            .height(with(LocalDensity.current) { (cursorRect.bottom - cursorRect.top).toDp() })
+                            .background(colorScheme.primary)
+                    )
+                }
+            }
+        }
 
         // Live preview
         val showPreview = result.isNotEmpty() && expression != result && expression.isNotEmpty()
@@ -479,4 +544,30 @@ fun HistorySheet(
 
 private fun formatExpression(expr: String): String {
     return expr.replace(Regex("([+\\-×÷])")) { " ${it.value} " }
+}
+
+private fun mapCursorToFormatted(raw: String, rawCursor: Int): Int {
+    var formattedPos = 0
+    for (i in 0 until rawCursor.coerceAtMost(raw.length)) {
+        if (raw[i] in listOf('+', '−', '×', '÷')) {
+            formattedPos += 3 // " X "
+        } else {
+            formattedPos += 1
+        }
+    }
+    return formattedPos
+}
+
+private fun mapCursorFromFormatted(raw: String, formattedCursor: Int): Int {
+    var fPos = 0
+    var rPos = 0
+    while (rPos < raw.length && fPos < formattedCursor) {
+        if (raw[rPos] in listOf('+', '−', '×', '÷')) {
+            fPos += 3
+        } else {
+            fPos += 1
+        }
+        rPos++
+    }
+    return rPos
 }

--- a/app/src/main/java/com/m3calculator/CalculatorViewModel.kt
+++ b/app/src/main/java/com/m3calculator/CalculatorViewModel.kt
@@ -1,6 +1,7 @@
 package com.m3calculator
 
 import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableIntStateOf
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.setValue
 import androidx.compose.runtime.mutableStateListOf
@@ -15,6 +16,8 @@ data class HistoryEntry(
 class CalculatorViewModel : ViewModel() {
     var expression by mutableStateOf("")
         private set
+    var cursorPosition by mutableIntStateOf(0)
+        private set
     var result by mutableStateOf("")
         private set
     var history by mutableStateOf("")
@@ -23,8 +26,25 @@ class CalculatorViewModel : ViewModel() {
     private val _historyList = mutableStateListOf<HistoryEntry>()
     val historyList: List<HistoryEntry> get() = _historyList
 
+    fun moveCursorTo(position: Int) {
+        cursorPosition = position.coerceIn(0, expression.length)
+    }
+
+    private fun insertAtCursor(text: String) {
+        expression = expression.substring(0, cursorPosition) + text + expression.substring(cursorPosition)
+        cursorPosition += text.length
+    }
+
+    private fun deleteAtCursor() {
+        if (cursorPosition > 0) {
+            expression = expression.substring(0, cursorPosition - 1) + expression.substring(cursorPosition)
+            cursorPosition--
+        }
+    }
+
     fun loadHistoryEntry(entry: HistoryEntry) {
         expression = entry.result
+        cursorPosition = entry.result.length
         result = ""
         history = "${entry.expression} ="
     }
@@ -37,12 +57,36 @@ class CalculatorViewModel : ViewModel() {
         when (label) {
             "AC" -> {
                 expression = ""
+                cursorPosition = 0
                 result = ""
                 history = ""
             }
             "⌫" -> {
-                if (expression.isNotEmpty()) {
-                    expression = expression.dropLast(1)
+                if (expression.isNotEmpty() && cursorPosition > 0) {
+                    val charBefore = expression[cursorPosition - 1]
+                    if (charBefore == '(' && cursorPosition >= 2 && expression[cursorPosition - 2] == '√') {
+                        // Delete √( together, and matching )
+                        val closingIndex = findMatchingClose(expression, cursorPosition - 1)
+                        expression = if (closingIndex != null) {
+                            expression.removeRange(closingIndex, closingIndex + 1)
+                                .removeRange(cursorPosition - 2, cursorPosition)
+                        } else {
+                            expression.removeRange(cursorPosition - 2, cursorPosition)
+                        }
+                        cursorPosition -= 2
+                    } else if (charBefore == ')') {
+                        val openIndex = findMatchingOpen(expression, cursorPosition - 1)
+                        if (openIndex != null && openIndex > 0 && expression[openIndex - 1] == '√') {
+                            // Delete √( and ), keep cursor at end of inner content
+                            expression = expression.removeRange(cursorPosition - 1, cursorPosition)
+                                .removeRange(openIndex - 1, openIndex + 1)
+                            cursorPosition = cursorPosition - 3
+                        } else {
+                            deleteAtCursor()
+                        }
+                    } else {
+                        deleteAtCursor()
+                    }
                     updatePreview()
                 }
             }
@@ -55,67 +99,89 @@ class CalculatorViewModel : ViewModel() {
                     }
                     result = res
                     expression = if (res == "Error") "" else res
+                    cursorPosition = expression.length
                 }
             }
             "+/−" -> {
-                expression = if (expression.startsWith("-")) {
-                    expression.drop(1)
+                if (expression.startsWith("-")) {
+                    expression = expression.drop(1)
+                    cursorPosition = (cursorPosition - 1).coerceAtLeast(0)
                 } else if (expression.isNotEmpty()) {
-                    "-$expression"
-                } else expression
-            }
-            "()" -> {
-                val openCount = expression.count { it == '(' }
-                val closeCount = expression.count { it == ')' }
-                expression += if (openCount == closeCount ||
-                    expression.isEmpty() ||
-                    expression.last() in listOf('+', '−', '×', '÷', '(')
-                ) "(" else ")"
+                    expression = "-$expression"
+                    cursorPosition++
+                }
             }
             "%" -> {
-                if (expression.isNotEmpty() && expression.last().isDigit()) {
-                    expression += "%"
+                val charBefore = if (cursorPosition > 0) expression[cursorPosition - 1] else null
+                if (charBefore != null && charBefore.isDigit()) {
+                    insertAtCursor("%")
                     updatePreview()
                 }
             }
             "√" -> {
                 if (expression.isNotEmpty()) {
                     expression = "√($expression)"
+                    cursorPosition = expression.length
                     updatePreview()
                 }
             }
             "π" -> {
-                expression += "π"
+                insertAtCursor("π")
                 updatePreview()
             }
             "^" -> {
-                if (expression.isNotEmpty() && expression.last().let { it.isDigit() || it == ')' || it == 'π' }) {
-                    expression += "^"
+                val charBefore = if (cursorPosition > 0) expression[cursorPosition - 1] else null
+                if (charBefore != null && (charBefore.isDigit() || charBefore == ')' || charBefore == 'π')) {
+                    insertAtCursor("^")
                 }
             }
             "!" -> {
-                if (expression.isNotEmpty() && expression.last().let { it.isDigit() || it == ')' }) {
-                    expression += "!"
+                val charBefore = if (cursorPosition > 0) expression[cursorPosition - 1] else null
+                if (charBefore != null && (charBefore.isDigit() || charBefore == ')')) {
+                    insertAtCursor("!")
                     updatePreview()
                 }
             }
             "+", "−", "×", "÷" -> {
-                if (expression.isNotEmpty() && expression.last() !in listOf('+', '−', '×', '÷')) {
-                    expression += label
+                val charBefore = if (cursorPosition > 0) expression[cursorPosition - 1] else null
+                if (charBefore != null && charBefore !in listOf('+', '−', '×', '÷')) {
+                    insertAtCursor(label)
                 }
             }
             "." -> {
-                val parts = expression.split(Regex("[+\\-×÷]"))
-                val lastPart = parts.lastOrNull() ?: ""
+                val before = expression.substring(0, cursorPosition)
+                val lastPart = before.split(Regex("[+\\-×÷]")).lastOrNull() ?: ""
                 if (!lastPart.contains(".")) {
-                    expression += label
+                    insertAtCursor(label)
                 }
             }
             else -> {
-                expression += label
+                insertAtCursor(label)
                 updatePreview()
             }
         }
+    }
+
+    private fun findMatchingClose(expr: String, openIndex: Int): Int? {
+        var depth = 1
+        for (i in (openIndex + 1) until expr.length) {
+            when (expr[i]) {
+                '(' -> depth++
+                ')' -> { depth--; if (depth == 0) return i }
+            }
+        }
+        return null
+    }
+
+    private fun findMatchingOpen(expr: String, closeIndex: Int): Int? {
+        var depth = 1
+        for (i in (closeIndex - 1) downTo 0) {
+            when (expr[i]) {
+                ')' -> depth++
+                '(' -> { depth--; if (depth == 0) return i }
+            }
+        }
+        return null
     }
 
     private fun updatePreview() {


### PR DESCRIPTION
- Tap anywhere in the expression to place cursor, input inserts there
- Custom blinking cursor drawn manually, no toolbar or keyboard
- Backspace is cursor-aware, deletes at cursor position
- Deleting √() brackets removes the whole sqrt wrapper
- Cursor hidden when at end of expression