### PR TITLE
Fix/reduce top padding

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -33,7 +33,7 @@ android {
         minSdk = 26
         targetSdk = 35
         versionCode = 1
-        versionName = "1.0.3"
+        versionName = "1.0.4"
 
         vectorDrawables {
             useSupportLibrary = true

--- a/app/src/main/java/com/m3calculator/CalculatorScreen.kt
+++ b/app/src/main/java/com/m3calculator/CalculatorScreen.kt
@@ -110,7 +110,7 @@ fun CalculatorScreen(viewModel: CalculatorViewModel) {
             Row(
                 modifier = Modifier
                     .fillMaxWidth()
-                    .padding(horizontal = 16.dp, vertical = 4.dp),
+                    .padding(horizontal = 16.dp),
                 horizontalArrangement = Arrangement.End
             ) {
                 IconButton(onClick = { showHistory = true }) {


### PR DESCRIPTION
- Remove vertical padding (8dp total) from the history button row, reducing the gap between the top bar and the expression display
- This gives more vertical space to the display area, helping prevent overflow on compact screens
- Bump version to 1.0.4