### PR TITLE
Strip trailing operators before evaluating on equals press

### DIFF
--- a/app/src/main/java/com/m3calculator/CalculatorViewModel.kt
+++ b/app/src/main/java/com/m3calculator/CalculatorViewModel.kt
@@ -96,6 +96,12 @@ class CalculatorViewModel : ViewModel() {
             }
             "=" -> {
                 if (expression.isNotEmpty()) {
+                    // Strip trailing operator before evaluating
+                    while (expression.isNotEmpty() && expression.last() in listOf('+', '−', '×', '÷')) {
+                        expression = expression.dropLast(1)
+                    }
+                    if (expression.isEmpty()) return
+                    cursorPosition = expression.length
                     val res = evaluate(expression)
                     history = "$expression ="
                     if (res != "Error") {


### PR DESCRIPTION
When the expression ends with an operator (e.g. "5+3×"), drop it before evaluating instead of showing an error.