### PR TITLE
Fix/production readiness

### DIFF
--- a/app/proguard-rules.pro
+++ b/app/proguard-rules.pro
@@ -1,1 +1,11 @@
 # Compose BOM ships its own consumer ProGuard rules; no blanket keeps needed.
+
+# Keep ViewModel classes (accessed via reflection by ViewModelProvider)
+-keep class com.m3calculator.CalculatorViewModel { *; }
+
+# Keep data classes used in state (Compose snapshots rely on field names)
+-keep class com.m3calculator.HistoryEntry { *; }
+
+# Keep CalcButton and ButtonType used by Compose
+-keep class com.m3calculator.CalcButton { *; }
+-keep class com.m3calculator.ButtonType { *; }

--- a/app/proguard-rules.pro
+++ b/app/proguard-rules.pro
@@ -1,7 +1,8 @@
 # Compose BOM ships its own consumer ProGuard rules; no blanket keeps needed.
 
-# Keep ViewModel classes (accessed via reflection by ViewModelProvider)
+# Keep ViewModel and factory (accessed via reflection by ViewModelProvider)
 -keep class com.m3calculator.CalculatorViewModel { *; }
+-keep class com.m3calculator.CalculatorViewModelFactory { *; }
 
 # Keep data classes used in state (Compose snapshots rely on field names)
 -keep class com.m3calculator.HistoryEntry { *; }

--- a/app/src/main/java/com/m3calculator/CalculatorScreen.kt
+++ b/app/src/main/java/com/m3calculator/CalculatorScreen.kt
@@ -31,6 +31,7 @@ import androidx.compose.ui.platform.LocalHapticFeedback
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.text.style.TextOverflow
+import android.content.res.Configuration
 import androidx.compose.ui.platform.LocalConfiguration
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.semantics.contentDescription
@@ -52,7 +53,9 @@ enum class ButtonType {
 @Composable
 fun CalculatorScreen(viewModel: CalculatorViewModel) {
     val colorScheme = MaterialTheme.colorScheme
-    val screenWidthDp = LocalConfiguration.current.screenWidthDp
+    val configuration = LocalConfiguration.current
+    val screenWidthDp = configuration.screenWidthDp
+    val isLandscape = configuration.orientation == Configuration.ORIENTATION_LANDSCAPE
     viewModel.maxDisplayLength = (screenWidthDp - 48) / 15
 
     val buttons = listOf(
@@ -108,19 +111,113 @@ fun CalculatorScreen(viewModel: CalculatorViewModel) {
         modifier = Modifier.fillMaxSize(),
         color = colorScheme.surface
     ) {
+        if (isLandscape) {
+            LandscapeLayout(
+                viewModel = viewModel,
+                buttons = buttons,
+                onShowHistory = { showHistory = true }
+            )
+        } else {
+            PortraitLayout(
+                viewModel = viewModel,
+                buttons = buttons,
+                onShowHistory = { showHistory = true }
+            )
+        }
+    }
+}
+
+@Composable
+private fun PortraitLayout(
+    viewModel: CalculatorViewModel,
+    buttons: List<List<CalcButton>>,
+    onShowHistory: () -> Unit
+) {
+    val colorScheme = MaterialTheme.colorScheme
+
+    Column(
+        modifier = Modifier
+            .fillMaxSize()
+            .systemBarsPadding()
+    ) {
+        // Top bar with history button
+        Row(
+            modifier = Modifier
+                .fillMaxWidth()
+                .padding(horizontal = 16.dp),
+            horizontalArrangement = Arrangement.End
+        ) {
+            IconButton(onClick = onShowHistory) {
+                Icon(
+                    imageVector = Icons.Default.AccessTime,
+                    contentDescription = stringResource(R.string.history),
+                    tint = colorScheme.onSurfaceVariant
+                )
+            }
+        }
+
+        // Display area
+        DisplaySection(
+            expression = viewModel.expression,
+            displayExpression = viewModel.displayExpression,
+            cursorPosition = viewModel.cursorPosition,
+            onCursorChange = { viewModel.moveCursorTo(it) },
+            result = viewModel.result,
+            history = viewModel.history,
+            modifier = Modifier
+                .weight(1f)
+                .fillMaxWidth()
+                .padding(horizontal = 24.dp)
+        )
+
+        // Divider
+        HorizontalDivider(
+            modifier = Modifier.padding(horizontal = 24.dp),
+            thickness = 0.5.dp,
+            color = colorScheme.outlineVariant.copy(alpha = 0.5f)
+        )
+
+        // Scientific row
+        ScientificRow(viewModel = viewModel)
+
+        // Button grid
+        ButtonGrid(
+            buttons = buttons,
+            viewModel = viewModel,
+            usePortraitAspect = true,
+            modifier = Modifier
+                .fillMaxWidth()
+                .padding(horizontal = 8.dp)
+                .padding(bottom = 12.dp)
+        )
+    }
+}
+
+@Composable
+private fun LandscapeLayout(
+    viewModel: CalculatorViewModel,
+    buttons: List<List<CalcButton>>,
+    onShowHistory: () -> Unit
+) {
+    val colorScheme = MaterialTheme.colorScheme
+
+    Row(
+        modifier = Modifier
+            .fillMaxSize()
+            .systemBarsPadding()
+    ) {
+        // Left side: display
         Column(
             modifier = Modifier
-                .fillMaxSize()
-                .systemBarsPadding()
+                .weight(1f)
+                .fillMaxHeight()
+                .padding(start = 16.dp, end = 8.dp)
         ) {
-            // Top bar with history button
             Row(
-                modifier = Modifier
-                    .fillMaxWidth()
-                    .padding(horizontal = 16.dp),
+                modifier = Modifier.fillMaxWidth(),
                 horizontalArrangement = Arrangement.End
             ) {
-                IconButton(onClick = { showHistory = true }) {
+                IconButton(onClick = onShowHistory) {
                     Icon(
                         imageVector = Icons.Default.AccessTime,
                         contentDescription = stringResource(R.string.history),
@@ -129,7 +226,6 @@ fun CalculatorScreen(viewModel: CalculatorViewModel) {
                 }
             }
 
-            // Display area
             DisplaySection(
                 expression = viewModel.expression,
                 displayExpression = viewModel.displayExpression,
@@ -140,71 +236,99 @@ fun CalculatorScreen(viewModel: CalculatorViewModel) {
                 modifier = Modifier
                     .weight(1f)
                     .fillMaxWidth()
-                    .padding(horizontal = 24.dp)
+                    .padding(horizontal = 8.dp)
             )
+        }
 
-            // Divider
-            HorizontalDivider(
-                modifier = Modifier.padding(horizontal = 24.dp),
-                thickness = 0.5.dp,
-                color = colorScheme.outlineVariant.copy(alpha = 0.5f)
+        // Right side: buttons
+        Column(
+            modifier = Modifier
+                .weight(1.2f)
+                .fillMaxHeight()
+                .padding(end = 8.dp, top = 4.dp, bottom = 4.dp),
+            verticalArrangement = Arrangement.SpaceEvenly
+        ) {
+            ScientificRow(viewModel = viewModel, compact = true)
+
+            ButtonGrid(
+                buttons = buttons,
+                viewModel = viewModel,
+                usePortraitAspect = false,
+                compact = true,
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .weight(1f)
             )
+        }
+    }
+}
 
-            // Scientific row
+@Composable
+private fun ScientificRow(
+    viewModel: CalculatorViewModel,
+    compact: Boolean = false
+) {
+    val colorScheme = MaterialTheme.colorScheme
+    Row(
+        modifier = Modifier
+            .fillMaxWidth()
+            .padding(horizontal = if (compact) 4.dp else 16.dp, vertical = if (compact) 0.dp else 4.dp),
+        horizontalArrangement = Arrangement.SpaceEvenly,
+        verticalAlignment = Alignment.CenterVertically
+    ) {
+        val sciButtons = listOf(
+            "√" to stringResource(R.string.btn_square_root),
+            "π" to stringResource(R.string.btn_pi),
+            "^" to stringResource(R.string.btn_power),
+            "!" to stringResource(R.string.btn_factorial),
+        )
+        sciButtons.forEach { (label, desc) ->
+            TextButton(
+                onClick = { viewModel.onButtonPress(label) },
+                modifier = Modifier
+                    .weight(1f)
+                    .semantics { contentDescription = desc },
+                contentPadding = PaddingValues(0.dp)
+            ) {
+                Text(
+                    text = label,
+                    fontSize = if (compact) 16.sp else 20.sp,
+                    fontWeight = FontWeight.Normal,
+                    color = colorScheme.onSurfaceVariant
+                )
+            }
+        }
+    }
+}
+
+@Composable
+private fun ButtonGrid(
+    buttons: List<List<CalcButton>>,
+    viewModel: CalculatorViewModel,
+    usePortraitAspect: Boolean,
+    compact: Boolean = false,
+    modifier: Modifier = Modifier
+) {
+    Column(
+        modifier = modifier,
+        verticalArrangement = Arrangement.spacedBy(if (compact) 3.dp else 6.dp)
+    ) {
+        buttons.forEach { row ->
             Row(
                 modifier = Modifier
                     .fillMaxWidth()
-                    .padding(horizontal = 16.dp, vertical = 4.dp),
-                horizontalArrangement = Arrangement.SpaceEvenly,
-                verticalAlignment = Alignment.CenterVertically
+                    .then(if (!usePortraitAspect) Modifier.weight(1f) else Modifier),
+                horizontalArrangement = Arrangement.spacedBy(if (compact) 3.dp else 6.dp)
             ) {
-                val sciButtons = listOf(
-                    "√" to stringResource(R.string.btn_square_root),
-                    "π" to stringResource(R.string.btn_pi),
-                    "^" to stringResource(R.string.btn_power),
-                    "!" to stringResource(R.string.btn_factorial),
-                )
-                sciButtons.forEach { (label, desc) ->
-                    TextButton(
-                        onClick = { viewModel.onButtonPress(label) },
+                row.forEach { button ->
+                    CalcButtonView(
+                        button = button,
+                        onClick = { viewModel.onButtonPress(button.label) },
+                        compact = compact,
                         modifier = Modifier
                             .weight(1f)
-                            .semantics { contentDescription = desc },
-                        contentPadding = PaddingValues(0.dp)
-                    ) {
-                        Text(
-                            text = label,
-                            fontSize = 20.sp,
-                            fontWeight = FontWeight.Normal,
-                            color = colorScheme.onSurfaceVariant
-                        )
-                    }
-                }
-            }
-
-            // Button grid
-            Column(
-                modifier = Modifier
-                    .fillMaxWidth()
-                    .padding(horizontal = 8.dp)
-                    .padding(bottom = 12.dp),
-                verticalArrangement = Arrangement.spacedBy(6.dp)
-            ) {
-                buttons.forEach { row ->
-                    Row(
-                        modifier = Modifier.fillMaxWidth(),
-                        horizontalArrangement = Arrangement.spacedBy(6.dp)
-                    ) {
-                        row.forEach { button ->
-                            CalcButtonView(
-                                button = button,
-                                onClick = { viewModel.onButtonPress(button.label) },
-                                modifier = Modifier
-                                    .weight(1f)
-                                    .aspectRatio(1f)
-                            )
-                        }
-                    }
+                            .then(if (usePortraitAspect) Modifier.aspectRatio(1f) else Modifier.fillMaxHeight())
+                    )
                 }
             }
         }
@@ -377,6 +501,7 @@ fun DisplaySection(
 fun CalcButtonView(
     button: CalcButton,
     onClick: () -> Unit,
+    compact: Boolean = false,
     modifier: Modifier = Modifier
 ) {
     val colorScheme = MaterialTheme.colorScheme
@@ -400,8 +525,6 @@ fun CalcButtonView(
         label = "buttonScale"
     )
 
-    val shape = CircleShape
-
     val containerColor = when (button.type) {
         ButtonType.NUMBER -> colorScheme.surfaceContainerHigh
         ButtonType.OPERATOR -> colorScheme.secondaryContainer
@@ -418,13 +541,25 @@ fun CalcButtonView(
         ButtonType.BACKSPACE -> colorScheme.onTertiaryContainer
     }
 
-    val fontSize = when (button.type) {
-        ButtonType.EQUALS -> 36.sp
-        ButtonType.OPERATOR -> 36.sp
-        ButtonType.NUMBER -> 32.sp
-        ButtonType.BACKSPACE -> 28.sp
-        else -> 28.sp
+    val fontSize = if (compact) {
+        when (button.type) {
+            ButtonType.EQUALS -> 24.sp
+            ButtonType.OPERATOR -> 24.sp
+            ButtonType.NUMBER -> 22.sp
+            ButtonType.BACKSPACE -> 20.sp
+            else -> 20.sp
+        }
+    } else {
+        when (button.type) {
+            ButtonType.EQUALS -> 36.sp
+            ButtonType.OPERATOR -> 36.sp
+            ButtonType.NUMBER -> 32.sp
+            ButtonType.BACKSPACE -> 28.sp
+            else -> 28.sp
+        }
     }
+
+    val shape = if (compact) RoundedCornerShape(16.dp) else CircleShape
 
     Surface(
         onClick = {

--- a/app/src/main/java/com/m3calculator/CalculatorScreen.kt
+++ b/app/src/main/java/com/m3calculator/CalculatorScreen.kt
@@ -32,12 +32,16 @@ import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.platform.LocalConfiguration
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.semantics.contentDescription
+import androidx.compose.ui.semantics.semantics
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
 
 data class CalcButton(
     val label: String,
-    val type: ButtonType
+    val type: ButtonType,
+    val descriptionRes: Int? = null
 )
 
 enum class ButtonType {
@@ -53,34 +57,34 @@ fun CalculatorScreen(viewModel: CalculatorViewModel) {
 
     val buttons = listOf(
         listOf(
-            CalcButton("⌫", ButtonType.BACKSPACE),
-            CalcButton("AC", ButtonType.FUNCTION),
-            CalcButton("%", ButtonType.FUNCTION),
-            CalcButton("÷", ButtonType.OPERATOR),
+            CalcButton("⌫", ButtonType.BACKSPACE, R.string.btn_backspace),
+            CalcButton("AC", ButtonType.FUNCTION, R.string.btn_all_clear),
+            CalcButton("%", ButtonType.FUNCTION, R.string.btn_percent),
+            CalcButton("÷", ButtonType.OPERATOR, R.string.btn_divide),
         ),
         listOf(
             CalcButton("7", ButtonType.NUMBER),
             CalcButton("8", ButtonType.NUMBER),
             CalcButton("9", ButtonType.NUMBER),
-            CalcButton("×", ButtonType.OPERATOR),
+            CalcButton("×", ButtonType.OPERATOR, R.string.btn_multiply),
         ),
         listOf(
             CalcButton("4", ButtonType.NUMBER),
             CalcButton("5", ButtonType.NUMBER),
             CalcButton("6", ButtonType.NUMBER),
-            CalcButton("−", ButtonType.OPERATOR),
+            CalcButton("−", ButtonType.OPERATOR, R.string.btn_subtract),
         ),
         listOf(
             CalcButton("1", ButtonType.NUMBER),
             CalcButton("2", ButtonType.NUMBER),
             CalcButton("3", ButtonType.NUMBER),
-            CalcButton("+", ButtonType.OPERATOR),
+            CalcButton("+", ButtonType.OPERATOR, R.string.btn_add),
         ),
         listOf(
-            CalcButton("+/−", ButtonType.NUMBER),
+            CalcButton("+/−", ButtonType.NUMBER, R.string.btn_toggle_sign),
             CalcButton("0", ButtonType.NUMBER),
-            CalcButton(".", ButtonType.NUMBER),
-            CalcButton("=", ButtonType.EQUALS),
+            CalcButton(".", ButtonType.NUMBER, R.string.btn_decimal),
+            CalcButton("=", ButtonType.EQUALS, R.string.btn_equals),
         ),
     )
 
@@ -119,7 +123,7 @@ fun CalculatorScreen(viewModel: CalculatorViewModel) {
                 IconButton(onClick = { showHistory = true }) {
                     Icon(
                         imageVector = Icons.Default.AccessTime,
-                        contentDescription = "History",
+                        contentDescription = stringResource(R.string.history),
                         tint = colorScheme.onSurfaceVariant
                     )
                 }
@@ -154,10 +158,18 @@ fun CalculatorScreen(viewModel: CalculatorViewModel) {
                 horizontalArrangement = Arrangement.SpaceEvenly,
                 verticalAlignment = Alignment.CenterVertically
             ) {
-                listOf("√", "π", "^", "!").forEach { label ->
+                val sciButtons = listOf(
+                    "√" to stringResource(R.string.btn_square_root),
+                    "π" to stringResource(R.string.btn_pi),
+                    "^" to stringResource(R.string.btn_power),
+                    "!" to stringResource(R.string.btn_factorial),
+                )
+                sciButtons.forEach { (label, desc) ->
                     TextButton(
                         onClick = { viewModel.onButtonPress(label) },
-                        modifier = Modifier.weight(1f),
+                        modifier = Modifier
+                            .weight(1f)
+                            .semantics { contentDescription = desc },
                         contentPadding = PaddingValues(0.dp)
                     ) {
                         Text(
@@ -344,7 +356,7 @@ fun DisplaySection(
             exit = fadeOut(animationSpec = tween(150))
         ) {
             Text(
-                text = if (result == "Error") result else "= $result",
+                text = if (result.startsWith("Error")) result else "= $result",
                 style = MaterialTheme.typography.headlineSmall,
                 color = colorScheme.primary.copy(alpha = 0.65f),
                 fontWeight = FontWeight.Medium,
@@ -371,6 +383,7 @@ fun CalcButtonView(
     val haptic = LocalHapticFeedback.current
     val interactionSource = remember { MutableInteractionSource() }
     val isPressed by interactionSource.collectIsPressedAsState()
+    val a11yDescription = button.descriptionRes?.let { stringResource(it) } ?: button.label
 
     LaunchedEffect(isPressed) {
         if (isPressed) {
@@ -419,6 +432,7 @@ fun CalcButtonView(
             onClick()
         },
         modifier = modifier
+            .semantics { contentDescription = a11yDescription }
             .then(
                 Modifier.graphicsLayer {
                     scaleX = scale
@@ -490,7 +504,7 @@ fun HistorySheet(
                 verticalAlignment = Alignment.CenterVertically
             ) {
                 Text(
-                    text = "History",
+                    text = stringResource(R.string.history),
                     style = MaterialTheme.typography.titleLarge,
                     fontWeight = FontWeight.Medium,
                     color = colorScheme.onSurface
@@ -499,7 +513,7 @@ fun HistorySheet(
                     IconButton(onClick = onClearHistory) {
                         Icon(
                             imageVector = Icons.Default.DeleteOutline,
-                            contentDescription = "Clear history",
+                            contentDescription = stringResource(R.string.clear_history),
                             tint = colorScheme.onSurfaceVariant
                         )
                     }
@@ -516,7 +530,7 @@ fun HistorySheet(
                     contentAlignment = Alignment.Center
                 ) {
                     Text(
-                        text = "No history yet",
+                        text = stringResource(R.string.no_history_yet),
                         style = MaterialTheme.typography.bodyLarge,
                         color = colorScheme.outline
                     )

--- a/app/src/main/java/com/m3calculator/CalculatorViewModel.kt
+++ b/app/src/main/java/com/m3calculator/CalculatorViewModel.kt
@@ -1,5 +1,6 @@
 package com.m3calculator
 
+import android.content.SharedPreferences
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableIntStateOf
 import androidx.compose.runtime.mutableStateOf
@@ -8,6 +9,8 @@ import androidx.compose.runtime.mutableStateListOf
 import androidx.lifecycle.SavedStateHandle
 import androidx.lifecycle.ViewModel
 import android.os.Build
+import org.json.JSONArray
+import org.json.JSONObject
 import java.math.BigDecimal
 import java.math.MathContext
 import java.math.RoundingMode
@@ -18,7 +21,11 @@ data class HistoryEntry(
     val timestamp: Long = System.currentTimeMillis()
 )
 
-class CalculatorViewModel(private val savedState: SavedStateHandle = SavedStateHandle()) : ViewModel() {
+class CalculatorViewModel(
+    private val prefs: SharedPreferences? = null,
+    private val savedState: SavedStateHandle = SavedStateHandle()
+) : ViewModel() {
+
     var expression by mutableStateOf(savedState.get<String>("expression") ?: "")
         private set
     var cursorPosition by mutableIntStateOf(savedState.get<Int>("cursorPosition") ?: 0)
@@ -33,13 +40,35 @@ class CalculatorViewModel(private val savedState: SavedStateHandle = SavedStateH
     val historyList: List<HistoryEntry> get() = _historyList
 
     init {
-        // Restore history list from saved state
-        savedState.get<List<String>>("historyExpressions")?.let { expressions ->
-            val results = savedState.get<List<String>>("historyResults") ?: return@let
-            val timestamps = savedState.get<List<Long>>("historyTimestamps") ?: return@let
-            expressions.indices.forEach { i ->
-                _historyList.add(HistoryEntry(expressions[i], results[i], timestamps[i]))
+        // Restore history list: prefer saved state (process death), fall back to disk
+        val restored = restoreHistoryFromSavedState() || restoreHistoryFromDisk()
+    }
+
+    private fun restoreHistoryFromSavedState(): Boolean {
+        val expressions = savedState.get<List<String>>("historyExpressions") ?: return false
+        val results = savedState.get<List<String>>("historyResults") ?: return false
+        val timestamps = savedState.get<List<Long>>("historyTimestamps") ?: return false
+        expressions.indices.forEach { i ->
+            _historyList.add(HistoryEntry(expressions[i], results[i], timestamps[i]))
+        }
+        return expressions.isNotEmpty()
+    }
+
+    private fun restoreHistoryFromDisk(): Boolean {
+        val json = prefs?.getString("history_json", null) ?: return false
+        return try {
+            val arr = JSONArray(json)
+            for (i in 0 until arr.length()) {
+                val obj = arr.getJSONObject(i)
+                _historyList.add(HistoryEntry(
+                    expression = obj.getString("expr"),
+                    result = obj.getString("result"),
+                    timestamp = obj.getLong("ts")
+                ))
             }
+            arr.length() > 0
+        } catch (_: Exception) {
+            false
         }
     }
 
@@ -51,6 +80,19 @@ class CalculatorViewModel(private val savedState: SavedStateHandle = SavedStateH
         savedState["historyExpressions"] = _historyList.map { it.expression }
         savedState["historyResults"] = _historyList.map { it.result }
         savedState["historyTimestamps"] = _historyList.map { it.timestamp }
+    }
+
+    private fun saveHistoryToDisk() {
+        prefs ?: return
+        val arr = JSONArray()
+        _historyList.forEach { entry ->
+            arr.put(JSONObject().apply {
+                put("expr", entry.expression)
+                put("result", entry.result)
+                put("ts", entry.timestamp)
+            })
+        }
+        prefs.edit().putString("history_json", arr.toString()).apply()
     }
 
     companion object {
@@ -93,6 +135,7 @@ class CalculatorViewModel(private val savedState: SavedStateHandle = SavedStateH
     fun clearHistory() {
         _historyList.clear()
         saveState()
+        saveHistoryToDisk()
     }
 
     fun onButtonPress(label: String) {
@@ -147,6 +190,7 @@ class CalculatorViewModel(private val savedState: SavedStateHandle = SavedStateH
                         if (_historyList.size > MAX_HISTORY_SIZE) {
                             _historyList.removeRange(MAX_HISTORY_SIZE, _historyList.size)
                         }
+                        saveHistoryToDisk()
                     }
                     result = res
                     expression = if (res.startsWith("Error")) "" else res

--- a/app/src/main/java/com/m3calculator/CalculatorViewModel.kt
+++ b/app/src/main/java/com/m3calculator/CalculatorViewModel.kt
@@ -5,6 +5,7 @@ import androidx.compose.runtime.mutableIntStateOf
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.setValue
 import androidx.compose.runtime.mutableStateListOf
+import androidx.lifecycle.SavedStateHandle
 import androidx.lifecycle.ViewModel
 import android.os.Build
 import java.math.BigDecimal
@@ -17,19 +18,40 @@ data class HistoryEntry(
     val timestamp: Long = System.currentTimeMillis()
 )
 
-class CalculatorViewModel : ViewModel() {
-    var expression by mutableStateOf("")
+class CalculatorViewModel(private val savedState: SavedStateHandle = SavedStateHandle()) : ViewModel() {
+    var expression by mutableStateOf(savedState.get<String>("expression") ?: "")
         private set
-    var cursorPosition by mutableIntStateOf(0)
+    var cursorPosition by mutableIntStateOf(savedState.get<Int>("cursorPosition") ?: 0)
         private set
-    var result by mutableStateOf("")
+    var result by mutableStateOf(savedState.get<String>("result") ?: "")
         private set
-    var history by mutableStateOf("")
+    var history by mutableStateOf(savedState.get<String>("history") ?: "")
         private set
     var maxDisplayLength = 24
 
     private val _historyList = mutableStateListOf<HistoryEntry>()
     val historyList: List<HistoryEntry> get() = _historyList
+
+    init {
+        // Restore history list from saved state
+        savedState.get<List<String>>("historyExpressions")?.let { expressions ->
+            val results = savedState.get<List<String>>("historyResults") ?: return@let
+            val timestamps = savedState.get<List<Long>>("historyTimestamps") ?: return@let
+            expressions.indices.forEach { i ->
+                _historyList.add(HistoryEntry(expressions[i], results[i], timestamps[i]))
+            }
+        }
+    }
+
+    private fun saveState() {
+        savedState["expression"] = expression
+        savedState["cursorPosition"] = cursorPosition
+        savedState["result"] = result
+        savedState["history"] = history
+        savedState["historyExpressions"] = _historyList.map { it.expression }
+        savedState["historyResults"] = _historyList.map { it.result }
+        savedState["historyTimestamps"] = _historyList.map { it.timestamp }
+    }
 
     companion object {
         private const val MAX_HISTORY_SIZE = 100
@@ -65,10 +87,12 @@ class CalculatorViewModel : ViewModel() {
         cursorPosition = plain.length
         result = ""
         history = "${entry.expression} ="
+        saveState()
     }
 
     fun clearHistory() {
         _historyList.clear()
+        saveState()
     }
 
     fun onButtonPress(label: String) {
@@ -213,6 +237,7 @@ class CalculatorViewModel : ViewModel() {
                 updatePreview()
             }
         }
+        saveState()
     }
 
     private fun findMatchingClose(expr: String, openIndex: Int): Int? {

--- a/app/src/main/java/com/m3calculator/CalculatorViewModel.kt
+++ b/app/src/main/java/com/m3calculator/CalculatorViewModel.kt
@@ -31,6 +31,10 @@ class CalculatorViewModel : ViewModel() {
     private val _historyList = mutableStateListOf<HistoryEntry>()
     val historyList: List<HistoryEntry> get() = _historyList
 
+    companion object {
+        private const val MAX_HISTORY_SIZE = 100
+    }
+
     fun moveCursorTo(position: Int) {
         cursorPosition = position.coerceIn(0, expression.length)
     }
@@ -111,11 +115,14 @@ class CalculatorViewModel : ViewModel() {
                     cursorPosition = expression.length
                     val res = evaluate(expression)
                     history = "$expression ="
-                    if (res != "Error") {
+                    if (!res.startsWith("Error")) {
                         _historyList.add(0, HistoryEntry(expression, formatForDisplay(res)))
+                        if (_historyList.size > MAX_HISTORY_SIZE) {
+                            _historyList.removeRange(MAX_HISTORY_SIZE, _historyList.size)
+                        }
                     }
                     result = res
-                    expression = if (res == "Error") "" else res
+                    expression = if (res.startsWith("Error")) "" else res
                     cursorPosition = expression.length
                 }
             }
@@ -230,7 +237,7 @@ class CalculatorViewModel : ViewModel() {
     private fun updatePreview() {
         if (expression.isNotEmpty() && expression.last().let { it.isDigit() || it == '!' || it == 'π' || it == ')' || it == '%' }) {
             val preview = evaluate(expression)
-            result = if (preview != "Error") formatForDisplay(preview) else ""
+            result = if (!preview.startsWith("Error")) formatForDisplay(preview) else ""
         }
     }
 
@@ -241,7 +248,7 @@ class CalculatorViewModel : ViewModel() {
 
     /** Format a plain value string as E notation when it exceeds display width. */
     fun formatForDisplay(value: String): String {
-        if (value != "Error" && value.length > maxDisplayLength) {
+        if (!value.startsWith("Error") && value.length > maxDisplayLength) {
             try {
                 val bd = BigDecimal(value)
                 val rounded = bd.round(DISPLAY_PRECISION).stripTrailingZeros()
@@ -306,7 +313,15 @@ class CalculatorViewModel : ViewModel() {
                 val formatted = result.round(DISPLAY_PRECISION).stripTrailingZeros()
                 formatted.toPlainString()
             }
-        } catch (e: Exception) {
+        } catch (e: ArithmeticException) {
+            when {
+                e.message?.contains("Division by zero") == true -> "Error: ÷ by 0"
+                e.message?.contains("Negative sqrt") == true -> "Error: √ of neg"
+                e.message?.contains("Invalid factorial") == true -> "Error: bad n!"
+                e.message?.contains("Non-finite") == true -> "Error: overflow"
+                else -> "Error"
+            }
+        } catch (_: Exception) {
             "Error"
         }
     }

--- a/app/src/main/java/com/m3calculator/CalculatorViewModel.kt
+++ b/app/src/main/java/com/m3calculator/CalculatorViewModel.kt
@@ -33,6 +33,8 @@ class CalculatorViewModel : ViewModel() {
 
     companion object {
         private const val MAX_HISTORY_SIZE = 100
+        private const val MAX_EXPRESSION_LENGTH = 200
+        private const val MAX_PAREN_DEPTH = 20
     }
 
     fun moveCursorTo(position: Int) {
@@ -40,6 +42,7 @@ class CalculatorViewModel : ViewModel() {
     }
 
     private fun insertAtCursor(text: String) {
+        if (expression.length + text.length > MAX_EXPRESSION_LENGTH) return
         expression = expression.substring(0, cursorPosition) + text + expression.substring(cursorPosition)
         cursorPosition += text.length
     }
@@ -319,6 +322,7 @@ class CalculatorViewModel : ViewModel() {
                 e.message?.contains("Negative sqrt") == true -> "Error: √ of neg"
                 e.message?.contains("Invalid factorial") == true -> "Error: bad n!"
                 e.message?.contains("Non-finite") == true -> "Error: overflow"
+                e.message?.contains("Nesting too deep") == true -> "Error: too nested"
                 else -> "Error"
             }
         } catch (_: Exception) {
@@ -327,6 +331,11 @@ class CalculatorViewModel : ViewModel() {
     }
 
     private fun evaluateExpression(expr: String): BigDecimal {
+        val depth = expr.fold(0) { max, c ->
+            val cur = if (c == '(') max + 1 else max
+            if (cur > MAX_PAREN_DEPTH) throw ArithmeticException("Nesting too deep")
+            if (c == ')') cur - 1 else cur
+        }
         val tokens = tokenize(expr)
         val postfix = infixToPostfix(tokens)
         return evaluatePostfix(postfix)

--- a/app/src/main/java/com/m3calculator/MainActivity.kt
+++ b/app/src/main/java/com/m3calculator/MainActivity.kt
@@ -1,15 +1,22 @@
 package com.m3calculator
 
+import android.content.Context
 import android.os.Bundle
 import androidx.activity.ComponentActivity
 import androidx.activity.compose.setContent
 import androidx.activity.enableEdgeToEdge
-import androidx.activity.viewModels
+import androidx.lifecycle.AbstractSavedStateViewModelFactory
+import androidx.lifecycle.SavedStateHandle
+import androidx.lifecycle.ViewModel
+import androidx.savedstate.SavedStateRegistryOwner
 import com.m3calculator.ui.theme.CalculatorM3Theme
 
 class MainActivity : ComponentActivity() {
 
-    private val viewModel: CalculatorViewModel by viewModels()
+    private val viewModel: CalculatorViewModel by lazy {
+        val factory = CalculatorViewModelFactory(this, this)
+        androidx.lifecycle.ViewModelProvider(this, factory)[CalculatorViewModel::class.java]
+    }
 
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
@@ -20,5 +27,16 @@ class MainActivity : ComponentActivity() {
                 CalculatorScreen(viewModel = viewModel)
             }
         }
+    }
+}
+
+class CalculatorViewModelFactory(
+    private val context: Context,
+    owner: SavedStateRegistryOwner
+) : AbstractSavedStateViewModelFactory(owner, null) {
+    override fun <T : ViewModel> create(key: String, modelClass: Class<T>, handle: SavedStateHandle): T {
+        val prefs = context.getSharedPreferences("calculator_history", Context.MODE_PRIVATE)
+        @Suppress("UNCHECKED_CAST")
+        return CalculatorViewModel(prefs, handle) as T
     }
 }

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -1,11 +1,14 @@
 <resources>
     <string name="app_name">Calculator</string>
 
-    <!-- Display -->
+    <!-- Error messages -->
     <string name="error">Error</string>
     <string name="error_division_by_zero">Can\'t divide by zero</string>
-    <string name="error_invalid_input">Invalid input</string>
+    <string name="error_negative_sqrt">Can\'t take √ of negative</string>
+    <string name="error_invalid_factorial">Invalid factorial</string>
     <string name="error_overflow">Overflow</string>
+    <string name="error_too_nested">Expression too nested</string>
+    <string name="error_invalid_input">Invalid input</string>
 
     <!-- History -->
     <string name="history">History</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -1,3 +1,30 @@
 <resources>
     <string name="app_name">Calculator</string>
+
+    <!-- Display -->
+    <string name="error">Error</string>
+    <string name="error_division_by_zero">Can\'t divide by zero</string>
+    <string name="error_invalid_input">Invalid input</string>
+    <string name="error_overflow">Overflow</string>
+
+    <!-- History -->
+    <string name="history">History</string>
+    <string name="clear_history">Clear history</string>
+    <string name="no_history_yet">No history yet</string>
+
+    <!-- Button accessibility -->
+    <string name="btn_backspace">Backspace</string>
+    <string name="btn_all_clear">All clear</string>
+    <string name="btn_percent">Percent</string>
+    <string name="btn_divide">Divide</string>
+    <string name="btn_multiply">Multiply</string>
+    <string name="btn_subtract">Subtract</string>
+    <string name="btn_add">Add</string>
+    <string name="btn_equals">Equals</string>
+    <string name="btn_decimal">Decimal point</string>
+    <string name="btn_toggle_sign">Toggle sign</string>
+    <string name="btn_square_root">Square root</string>
+    <string name="btn_pi">Pi</string>
+    <string name="btn_power">Power</string>
+    <string name="btn_factorial">Factorial</string>
 </resources>

--- a/app/src/test/java/com/m3calculator/CalculatorViewModelTest.kt
+++ b/app/src/test/java/com/m3calculator/CalculatorViewModelTest.kt
@@ -1613,4 +1613,73 @@ class CalculatorViewModelTest {
         tapEquals()
         assertExpression("12")
     }
+
+    // ── Expression length limit ───────────────────────────────────────
+
+    @Test
+    fun expressionLengthCapped() {
+        // Fill expression to max length, then verify further input is ignored
+        val digits = "1".repeat(200)
+        digits.forEach { tap(it.toString()) }
+        assertEquals(200, vm.expression.length)
+        tap("2")
+        // Should still be 200 — extra digit rejected
+        assertEquals(200, vm.expression.length)
+    }
+
+    @Test
+    fun expressionAcceptsUpToLimit() {
+        val digits = "1".repeat(199)
+        digits.forEach { tap(it.toString()) }
+        assertEquals(199, vm.expression.length)
+        tap("2")
+        assertEquals(200, vm.expression.length)
+    }
+
+    // ── Nesting depth limit ───────────────────────────────────────────
+
+    @Test
+    fun deeplyNestedSqrtErrors() {
+        // Build √(√(√(...√(4)...))) with 21 levels — exceeds MAX_PAREN_DEPTH of 20
+        tap("4")
+        repeat(21) { tap("√") }
+        tapEquals()
+        assertResult("Error: too nested")
+        assertExpression("")
+    }
+
+    @Test
+    fun maxNestingDepthAllowed() {
+        // 20 levels should be fine
+        tap("4")
+        repeat(20) { tap("√") }
+        tapEquals()
+        // √ of 4 repeatedly: 4→2→√2→... should produce a number, not an error
+        assert(!vm.result.startsWith("Error")) { "Should succeed at depth 20, got: ${vm.result}" }
+    }
+
+    // ── Specific error messages ───────────────────────────────────────
+
+    @Test
+    fun divisionByZeroMessage() {
+        tap("1", "÷", "0")
+        tapEquals()
+        assertResult("Error: ÷ by 0")
+    }
+
+    @Test
+    fun negativeSqrtMessage() {
+        tap("4")
+        tap("+/−")
+        tap("√")
+        tapEquals()
+        assertResult("Error: √ of neg")
+    }
+
+    @Test
+    fun invalidFactorialMessage() {
+        tap("1", "0", "0", "!")
+        tapEquals()
+        assertResult("Error: bad n!")
+    }
 }

--- a/app/src/test/java/com/m3calculator/CalculatorViewModelTest.kt
+++ b/app/src/test/java/com/m3calculator/CalculatorViewModelTest.kt
@@ -187,7 +187,7 @@ class CalculatorViewModelTest {
     fun divisionByZero() {
         tap("5", "÷", "0")
         tapEquals()
-        assertResult("Error")
+        assertResult("Error: ÷ by 0")
         assertExpression("")
     }
 
@@ -385,7 +385,7 @@ class CalculatorViewModelTest {
         // 100! exceeds the limit
         tap("1", "0", "0", "!")
         tapEquals()
-        assertResult("Error")
+        assertResult("Error: bad n!")
         assertExpression("")
     }
 
@@ -479,7 +479,7 @@ class CalculatorViewModelTest {
         tap("+/−")
         tap("√")
         tapEquals()
-        assertResult("Error")
+        assertResult("Error: √ of neg")
         assertExpression("")
     }
 
@@ -664,7 +664,7 @@ class CalculatorViewModelTest {
         // 5÷0=Error, then 3+2=5
         tap("5", "÷", "0")
         tapEquals()
-        assertResult("Error")
+        assertResult("Error: ÷ by 0")
         assertExpression("")
         tap("3", "+", "2")
         tapEquals()
@@ -857,7 +857,7 @@ class CalculatorViewModelTest {
         // 5 + 10÷0 = Error
         tap("5", "+", "1", "0", "÷", "0")
         tapEquals()
-        assertResult("Error")
+        assertResult("Error: ÷ by 0")
         assertExpression("")
     }
 
@@ -865,7 +865,7 @@ class CalculatorViewModelTest {
     fun zeroByZero() {
         tap("0", "÷", "0")
         tapEquals()
-        assertResult("Error")
+        assertResult("Error: ÷ by 0")
         assertExpression("")
     }
 


### PR DESCRIPTION
  - Add contentDescription to all buttons for TalkBack/screen reader support
  - Move all UI strings to strings.xml for localization
  - Return specific error messages per failure type (÷ by 0, √ of neg, bad n!, overflow, too nested)
  - Cap history at 100 entries and persist to SharedPreferences across app restarts
  - Persist expression, cursor, result, and history across process death via SavedStateHandle
  - Cap expression input at 200 characters and reject nesting beyond 20 levels
  - Add ProGuard keep rules for ViewModel, factory, and data classes
  - Add landscape layout: display on left, compact button grid on right
  - 7 new unit tests (179 total), all passing