### PR TITLE
Feature/calculator fixes

### DIFF
--- a/app/src/main/java/com/m3calculator/CalculatorScreen.kt
+++ b/app/src/main/java/com/m3calculator/CalculatorScreen.kt
@@ -565,10 +565,7 @@ fun CalcButtonView(
     val shape = if (compact) RoundedCornerShape(16.dp) else CircleShape
 
     Surface(
-        onClick = {
-            haptic.performHapticFeedback(HapticFeedbackType.TextHandleMove)
-            onClick()
-        },
+        onClick = onClick,
         modifier = modifier
             .semantics { contentDescription = a11yDescription }
             .then(

--- a/app/src/main/java/com/m3calculator/CalculatorScreen.kt
+++ b/app/src/main/java/com/m3calculator/CalculatorScreen.kt
@@ -454,7 +454,10 @@ fun DisplaySection(
 
                 if (cursorVisible && blinkVisible && readyToDraw) {
                     textLayoutResult.value?.let { layout ->
-                        val cursorOffset = cursorInFormatted.coerceAtMost(displayText.length)
+                        // Coerce to the layout's actual text length to avoid crash
+                        // when the layout is stale (not yet updated for the new expression)
+                        val layoutLen = layout.layoutInput.text.length
+                        val cursorOffset = cursorInFormatted.coerceIn(0, layoutLen)
                         val cursorRect = layout.getCursorRect(cursorOffset)
                         Box(
                             modifier = Modifier
@@ -715,9 +718,11 @@ fun HistorySheet(
 }
 
 private fun formatExpression(expr: String): String {
-    // Add spaces around binary operators but not a leading unary minus
-    // from +/− toggle and not the sign in E notation (e.g. E+30)
-    return expr.replace(Regex("(?<=.)(?<![Ee])[+\\-×÷−]")) { " ${it.value} " }
+    // Add spaces around binary operators (Unicode −, ×, ÷, and ASCII +).
+    // ASCII '-' (from +/− toggle or history load) is always a unary sign prefix,
+    // so it must NOT get spaces — otherwise cursor mapping breaks.
+    // Also skip the sign in E notation (e.g. E+30).
+    return expr.replace(Regex("(?<=.)(?<![Ee])[+×÷−]")) { " ${it.value} " }
 }
 
 private fun mapCursorToFormatted(raw: String, rawCursor: Int): Int {

--- a/app/src/main/java/com/m3calculator/CalculatorViewModel.kt
+++ b/app/src/main/java/com/m3calculator/CalculatorViewModel.kt
@@ -198,11 +198,23 @@ class CalculatorViewModel(
                 }
             }
             "+/−" -> {
-                if (expression.startsWith("-")) {
-                    expression = expression.drop(1)
-                    cursorPosition = (cursorPosition - 1).coerceAtLeast(0)
-                } else if (expression.isNotEmpty()) {
-                    expression = "-$expression"
+                if (expression.isEmpty()) return
+                // Find the start of the operand the cursor is in
+                val boundaryChars = setOf('+', '−', '×', '÷', '^', '(', ')', '√', '!')
+                val operandStart = (cursorPosition - 1 downTo 0)
+                    .firstOrNull { expression[it] in boundaryChars }
+                    ?.plus(1) ?: 0
+
+                // If no operand at cursor (e.g. cursor after ')'), negate whole expression
+                val effectiveStart = if (operandStart >= cursorPosition && operandStart > 0) 0 else operandStart
+
+                if (effectiveStart < expression.length && expression[effectiveStart] == '-') {
+                    // Remove existing negative sign
+                    expression = expression.removeRange(effectiveStart, effectiveStart + 1)
+                    cursorPosition = (cursorPosition - 1).coerceAtLeast(effectiveStart)
+                } else {
+                    // Insert negative sign at start of operand
+                    expression = expression.substring(0, effectiveStart) + "-" + expression.substring(effectiveStart)
                     cursorPosition++
                 }
                 updatePreview()

--- a/app/src/main/java/com/m3calculator/CalculatorViewModel.kt
+++ b/app/src/main/java/com/m3calculator/CalculatorViewModel.kt
@@ -243,19 +243,8 @@ class CalculatorViewModel(
                 val charBefore = if (cursorPosition > 0) expression[cursorPosition - 1] else null
                 val charAfter = if (cursorPosition < expression.length) expression[cursorPosition] else null
                 if (charBefore != null && charBefore in operators) {
-                    if (label == "−" && charBefore != '−') {
-                        // Allow minus after operator as unary minus (e.g. 6+−5)
-                        // But don't allow −− (double unary minus)
-                        insertAtCursor(label)
-                    } else {
-                        // Replace operator(s) before cursor — collapse unary minus + operator
-                        var replaceStart = cursorPosition - 1
-                        if (replaceStart > 0 && expression[replaceStart - 1] in operators) {
-                            replaceStart-- // also remove the operator before unary minus
-                        }
-                        expression = expression.substring(0, replaceStart) + label + expression.substring(cursorPosition)
-                        cursorPosition = replaceStart + 1
-                    }
+                    // Replace the operator before cursor
+                    expression = expression.substring(0, cursorPosition - 1) + label + expression.substring(cursorPosition)
                 } else if (charBefore != null && charBefore !in operators) {
                     if (charAfter != null && charAfter in operators) {
                         // Replace the operator after cursor

--- a/app/src/main/java/com/m3calculator/CalculatorViewModel.kt
+++ b/app/src/main/java/com/m3calculator/CalculatorViewModel.kt
@@ -177,6 +177,10 @@ class CalculatorViewModel(
             }
             "=" -> {
                 if (expression.isNotEmpty()) {
+                    // Strip leading operators that need a left operand
+                    while (expression.isNotEmpty() && expression.first() in listOf('+', '×', '÷', '^')) {
+                        expression = expression.drop(1)
+                    }
                     // Strip trailing operator before evaluating
                     while (expression.isNotEmpty() && expression.last() in listOf('+', '−', '×', '÷', '^')) {
                         expression = expression.dropLast(1)
@@ -257,7 +261,7 @@ class CalculatorViewModel(
                 if (charBefore != null && charBefore in operators) {
                     // Replace the operator before cursor
                     expression = expression.substring(0, cursorPosition - 1) + label + expression.substring(cursorPosition)
-                } else if (charBefore != null && charBefore !in operators) {
+                } else {
                     if (charAfter != null && charAfter in operators) {
                         // Replace the operator after cursor
                         expression = expression.substring(0, cursorPosition) + label + expression.substring(cursorPosition + 1)

--- a/app/src/main/java/com/m3calculator/CalculatorViewModel.kt
+++ b/app/src/main/java/com/m3calculator/CalculatorViewModel.kt
@@ -374,9 +374,8 @@ class CalculatorViewModel(
                 .replace("×", "*")
                 .replace("÷", "/")
                 .replace("−", "-")
-                // % → /100, with implicit multiply when followed by a digit
-                .replace(Regex("%(\\d)"), "/100*$1")
-                .replace("%", "/100")
+                // Implicit multiply after %: 50%3 → 50%*3
+                .replace(Regex("%(\\d)"), "%*$1")
                 // Implicit multiplication around π
                 .replace(Regex("(\\d)π"), "$1*π")
                 .replace(Regex("π(\\d)"), "π*$1")
@@ -474,9 +473,8 @@ class CalculatorViewModel(
                 c == '/' -> tokens.add(Token.Op('/', 2))
                 c == '^' -> tokens.add(Token.Op('^', 3, leftAssoc = false))
                 c == '√' -> tokens.add(Token.UnaryOp('√'))
-                c == '!' -> {
-                    tokens.add(Token.UnaryOp('!'))
-                }
+                c == '!' -> tokens.add(Token.UnaryOp('!'))
+                c == '%' -> tokens.add(Token.UnaryOp('%'))
             }
             i++
         }
@@ -503,10 +501,10 @@ class CalculatorViewModel(
                     stack.addLast(token)
                 }
                 is Token.UnaryOp -> {
-                    if (token.op == '!') {
-                        output.add(token)
+                    if (token.op == '!' || token.op == '%') {
+                        output.add(token) // postfix unary: immediately output
                     } else {
-                        stack.addLast(token)
+                        stack.addLast(token) // prefix unary (√): push to stack
                     }
                 }
                 is Token.LParen -> stack.addLast(token)
@@ -525,59 +523,67 @@ class CalculatorViewModel(
         return output
     }
 
+    /** Stack entry: value + flag indicating it came from % (for consumer-style percent). */
+    private data class SVal(val v: BigDecimal, val pct: Boolean = false)
+
     private fun evaluatePostfix(tokens: List<Token>): BigDecimal {
-        val stack = ArrayDeque<BigDecimal>()
+        val stack = ArrayDeque<SVal>()
         for (token in tokens) {
             when (token) {
-                is Token.Num -> stack.addLast(token.value)
+                is Token.Num -> stack.addLast(SVal(token.value))
                 is Token.Op -> {
                     if (stack.size < 2) throw ArithmeticException("Insufficient operands")
                     val b = stack.removeLast()
                     val a = stack.removeLast()
                     val result = when (token.op) {
-                        '+' -> a.add(b, MC)
-                        '-' -> a.subtract(b, MC)
-                        '*' -> a.multiply(b, MC)
+                        '+' -> if (b.pct) a.v.add(a.v.multiply(b.v, MC), MC)
+                               else a.v.add(b.v, MC)
+                        '-' -> if (b.pct) a.v.subtract(a.v.multiply(b.v, MC), MC)
+                               else a.v.subtract(b.v, MC)
+                        '*' -> a.v.multiply(b.v, MC)
                         '/' -> {
-                            if (b.compareTo(BigDecimal.ZERO) == 0) throw ArithmeticException("Division by zero")
-                            a.divide(b, MC)
+                            if (b.v.compareTo(BigDecimal.ZERO) == 0) throw ArithmeticException("Division by zero")
+                            a.v.divide(b.v, MC)
                         }
                         '^' -> {
-                            val bExact = try { b.intValueExact() } catch (_: ArithmeticException) { null }
+                            val bExact = try { b.v.intValueExact() } catch (_: ArithmeticException) { null }
                             if (bExact != null && bExact in -999..999) {
-                                if (bExact >= 0) a.pow(bExact, MC)
-                                else BigDecimal.ONE.divide(a.pow(-bExact, MC), MC)
+                                if (bExact >= 0) a.v.pow(bExact, MC)
+                                else BigDecimal.ONE.divide(a.v.pow(-bExact, MC), MC)
                             } else {
-                                val dResult = Math.pow(a.toDouble(), b.toDouble())
+                                val dResult = Math.pow(a.v.toDouble(), b.v.toDouble())
                                 if (!dResult.isFinite()) throw ArithmeticException("Non-finite result")
                                 BigDecimal.valueOf(dResult)
                             }
                         }
                         else -> throw ArithmeticException("Unknown operator")
                     }
-                    stack.addLast(result)
+                    stack.addLast(SVal(result))
                 }
                 is Token.UnaryOp -> {
                     if (stack.isEmpty()) throw ArithmeticException("Insufficient operands")
                     val a = stack.removeLast()
-                    val result = when (token.op) {
+                    when (token.op) {
                         '√' -> {
-                            if (a < BigDecimal.ZERO) throw ArithmeticException("Negative sqrt")
-                            bigSqrt(a)
+                            if (a.v < BigDecimal.ZERO) throw ArithmeticException("Negative sqrt")
+                            stack.addLast(SVal(bigSqrt(a.v)))
                         }
                         '!' -> {
-                            val intVal = try { a.intValueExact() } catch (_: ArithmeticException) { -1 }
+                            val intVal = try { a.v.intValueExact() } catch (_: ArithmeticException) { -1 }
                             if (intVal < 0 || intVal > 99) throw ArithmeticException("Invalid factorial")
-                            factorial(intVal.toLong())
+                            stack.addLast(SVal(factorial(intVal.toLong())))
+                        }
+                        '%' -> {
+                            // Divide by 100, flag as percent for consumer-style + and -
+                            stack.addLast(SVal(a.v.divide(HUNDRED, MC), pct = true))
                         }
                         else -> throw ArithmeticException("Unknown operator")
                     }
-                    stack.addLast(result)
                 }
                 else -> {}
             }
         }
-        return stack.lastOrNull() ?: throw ArithmeticException("Empty expression")
+        return stack.lastOrNull()?.v ?: throw ArithmeticException("Empty expression")
     }
 
     private fun bigSqrt(a: BigDecimal): BigDecimal {

--- a/app/src/main/java/com/m3calculator/CalculatorViewModel.kt
+++ b/app/src/main/java/com/m3calculator/CalculatorViewModel.kt
@@ -209,8 +209,17 @@ class CalculatorViewModel(
                     .firstOrNull { expression[it] in boundaryChars }
                     ?.plus(1) ?: 0
 
-                // If no operand at cursor (e.g. cursor after ')'), negate whole expression
-                val effectiveStart = if (operandStart >= cursorPosition && operandStart > 0) 0 else operandStart
+                // If cursor is right at a boundary, check if there's an operand ahead
+                val effectiveStart = if (operandStart >= cursorPosition && operandStart > 0) {
+                    val ch = expression.getOrNull(operandStart)
+                    if (ch != null && (ch.isDigit() || ch == '.' || ch == '-' || ch == 'π')) {
+                        operandStart // negate the operand starting here
+                    } else {
+                        0 // no operand ahead (e.g. after ')'), negate whole expression
+                    }
+                } else {
+                    operandStart
+                }
 
                 if (effectiveStart < expression.length && expression[effectiveStart] == '-') {
                     // Remove existing negative sign

--- a/app/src/main/java/com/m3calculator/CalculatorViewModel.kt
+++ b/app/src/main/java/com/m3calculator/CalculatorViewModel.kt
@@ -257,7 +257,7 @@ class CalculatorViewModel(
             }
             "." -> {
                 // Check the full operand around the cursor (not just before it)
-                val operatorChars = setOf('+', '-', '×', '÷', '−')
+                val operatorChars = setOf('+', '-', '×', '÷', '−', '^', '(', ')', '√', '!')
                 val start = (cursorPosition - 1 downTo 0).firstOrNull { expression[it] in operatorChars }?.plus(1) ?: 0
                 val end = (cursorPosition until expression.length).firstOrNull { expression[it] in operatorChars } ?: expression.length
                 val operand = expression.substring(start, end)

--- a/app/src/test/java/com/m3calculator/CalculatorViewModelTest.kt
+++ b/app/src/test/java/com/m3calculator/CalculatorViewModelTest.kt
@@ -668,6 +668,26 @@ class CalculatorViewModelTest {
         assertExpression("7")
     }
 
+    @Test
+    fun signToggleInsideSqrtNegatesNumber() {
+        // √(9) with cursor inside → negate number, not whole sqrt
+        tap("9", "√")
+        assertExpression("√(9)")
+        vm.moveCursorTo(2) // right after (
+        tap("+/−")
+        assertExpression("√(-9)")
+    }
+
+    @Test
+    fun signToggleInsideSqrtTogglesBack() {
+        tap("9", "√")
+        vm.moveCursorTo(3) // on the 9
+        tap("+/−")
+        assertExpression("√(-9)")
+        tap("+/−") // toggle back
+        assertExpression("√(9)")
+    }
+
     // ── Result carry-over complex ──────────────────────────────────────
 
     @Test

--- a/app/src/test/java/com/m3calculator/CalculatorViewModelTest.kt
+++ b/app/src/test/java/com/m3calculator/CalculatorViewModelTest.kt
@@ -1586,6 +1586,22 @@ class CalculatorViewModelTest {
         assertExpression("12")
     }
 
+    // ── Decimal guard with operand boundaries ──────────────────────────
+
+    @Test
+    fun decimalAllowedInExponentAfterCaret() {
+        // 2.5^3.5 — caret separates operands, so second decimal is valid
+        tap("2", ".", "5", "^", "3", ".", "5")
+        assertExpression("2.5^3.5")
+    }
+
+    @Test
+    fun decimalAllowedInsideParentheses() {
+        // √(2.5) then add decimal to outer operand
+        tap("2", ".", "5", "√", "+", "1", ".")
+        assertExpression("√(2.5)+1.")
+    }
+
     // ── Expression length limit ───────────────────────────────────────
 
     @Test

--- a/app/src/test/java/com/m3calculator/CalculatorViewModelTest.kt
+++ b/app/src/test/java/com/m3calculator/CalculatorViewModelTest.kt
@@ -622,14 +622,44 @@ class CalculatorViewModelTest {
         tap("5", "+", "3")
         assertResult("8")
         tap("+/−")
-        // -5+3 = -2
-        assertResult("-2")
+        // 5+-3 = 2 (negates current operand "3", not whole expression)
+        assertExpression("5+-3")
+        assertResult("2")
     }
 
     @Test
     fun signToggleOnEmpty() {
         tap("+/−")
         assertExpression("")
+    }
+
+    @Test
+    fun signToggleSecondOperand() {
+        // 5+3, toggle → 5+-3, toggle again → 5+3
+        tap("5", "+", "3")
+        tap("+/−")
+        assertExpression("5+-3")
+        tap("+/−")
+        assertExpression("5+3")
+    }
+
+    @Test
+    fun signToggleFirstOperandViaCursor() {
+        // 5+3, move cursor into first operand, toggle
+        tap("5", "+", "3")
+        vm.moveCursorTo(1) // after "5"
+        tap("+/−")
+        assertExpression("-5+3")
+    }
+
+    @Test
+    fun signToggleSecondOperandEvaluates() {
+        // 10+−3 = 7
+        tap("1", "0", "+", "3")
+        tap("+/−")
+        assertExpression("10+-3")
+        tapEquals()
+        assertExpression("7")
     }
 
     // ── Result carry-over complex ──────────────────────────────────────

--- a/app/src/test/java/com/m3calculator/CalculatorViewModelTest.kt
+++ b/app/src/test/java/com/m3calculator/CalculatorViewModelTest.kt
@@ -569,10 +569,10 @@ class CalculatorViewModelTest {
 
     @Test
     fun percentageInAddition() {
-        // 200 + 50% = 200 + 0.5 = 200.5
+        // 200 + 50% = 200 + (50% of 200) = 200 + 100 = 300
         tap("2", "0", "0", "+", "5", "0", "%")
         tapEquals()
-        assertExpression("200.5")
+        assertExpression("300")
     }
 
     @Test
@@ -1100,6 +1100,22 @@ class CalculatorViewModelTest {
         tap("5", "0", "%", "×", "2", "0", "0")
         tapEquals()
         assertExpression("100")
+    }
+
+    @Test
+    fun percentageInSubtraction() {
+        // 200 - 10% = 200 - (10% of 200) = 200 - 20 = 180
+        tap("2", "0", "0", "−", "1", "0", "%")
+        tapEquals()
+        assertExpression("180")
+    }
+
+    @Test
+    fun percentageStandalone() {
+        // 50% = 0.5
+        tap("5", "0", "%")
+        tapEquals()
+        assertExpression("0.5")
     }
 
     @Test

--- a/app/src/test/java/com/m3calculator/CalculatorViewModelTest.kt
+++ b/app/src/test/java/com/m3calculator/CalculatorViewModelTest.kt
@@ -790,40 +790,12 @@ class CalculatorViewModelTest {
     }
 
     @Test
-    fun unaryMinusAfterOperator() {
-        // − after operator inserts as unary minus
+    fun minusReplacesOperator() {
+        // − after + should replace it, just like any other operator
         tap("5", "+", "−")
-        assertExpression("5+−")
-    }
-
-    @Test
-    fun unaryMinusInExpression() {
-        // 6+−5 = 1
-        tap("6", "+", "−", "5")
-        tapEquals()
-        assertExpression("1")
-    }
-
-    @Test
-    fun unaryMinusWithMultiply() {
-        // 6×−5 = -30
-        tap("6", "×", "−", "5")
-        tapEquals()
-        assertExpression("-30")
-    }
-
-    @Test
-    fun replaceUnaryMinusWithOperator() {
-        // Typing × after +− should collapse to just ×
-        tap("5", "+", "−", "×")
-        assertExpression("5×")
-    }
-
-    @Test
-    fun doubleUnaryMinusBlocked() {
-        // −− should not be allowed, second − replaces first
-        tap("5", "+", "−", "−")
         assertExpression("5−")
+        tap("+")
+        assertExpression("5+")
     }
 
     @Test

--- a/app/src/test/java/com/m3calculator/CalculatorViewModelTest.kt
+++ b/app/src/test/java/com/m3calculator/CalculatorViewModelTest.kt
@@ -236,9 +236,15 @@ class CalculatorViewModelTest {
     }
 
     @Test
-    fun noLeadingOperator() {
+    fun leadingOperatorAllowed() {
         tap("+")
-        assertExpression("")
+        assertExpression("+")
+    }
+
+    @Test
+    fun leadingOperatorStrippedOnEquals() {
+        tap("+", "5", "=")
+        assertExpression("5")
     }
 
     // ── Preview ─────────────────────────────────────────────────────
@@ -798,15 +804,32 @@ class CalculatorViewModelTest {
     // ── Input guard stress tests ───────────────────────────────────────
 
     @Test
-    fun allOperatorsBlockedAtStart() {
+    fun allOperatorsAllowedAtStart() {
         tap("+")
-        assertExpression("")
+        assertExpression("+")
+        tap("AC")
         tap("−")
-        assertExpression("")
+        assertExpression("−")
+        tap("AC")
         tap("×")
-        assertExpression("")
+        assertExpression("×")
+        tap("AC")
         tap("÷")
-        assertExpression("")
+        assertExpression("÷")
+    }
+
+    @Test
+    fun leadingMultiplyStrippedOnEquals() {
+        tap("×", "3", "=")
+        assertExpression("3")
+    }
+
+    @Test
+    fun leadingMinusKeptOnEquals() {
+        // − is valid unary minus, should not be stripped
+        tap("−", "5", "=")
+        // evaluates −5 → result is -5
+        assertExpression("-5")
     }
 
     @Test


### PR DESCRIPTION
- Minus operator parity: minus now replaces adjacent operators like all other operators instead of inserting as unary minus
- Decimal guard: ^, (, ), √, and ! are now treated as operand boundaries, allowing decimals in each operand (e.g., 2.5^3.5)
- Per-operand sign toggle: +/− now negates only the current operand at the cursor, not the entire expression. Also works correctly inside √(...) parentheses
- Cursor crash fix: coerce cursor offset to the text layout's actual length to prevent IndexOutOfBoundsException when the layout is stale after expression changes
- Cursor mapping fix: ASCII - from +/− toggle no longer gets spaces in formatExpression, fixing cursor position mismatches
- Operators at start: operators can now be inserted at position 0; invalid leading operators (+, ×, ÷, ^) are stripped on equals
- Consumer-style percentage: 100+50% now evaluates as 150 (50% of 100 added), matching standard calculator behavior. × and ÷ with % remain plain division by 100
- Haptic fix: removed duplicate haptic feedback that fired on both press and click