### PR TITLE
Fix %π implicit multiply and reject malformed postfix expressions

### DIFF
--- a/app/src/main/java/com/m3calculator/CalculatorViewModel.kt
+++ b/app/src/main/java/com/m3calculator/CalculatorViewModel.kt
@@ -375,8 +375,9 @@ class CalculatorViewModel(
                 .replace("×", "*")
                 .replace("÷", "/")
                 .replace("−", "-")
-                // Implicit multiply after %: 50%3 → 50%*3
+                // Implicit multiply after %: 50%3 → 50%*3, 50%π → 50%*π
                 .replace(Regex("%(\\d)"), "%*$1")
+                .replace(Regex("%π"), "%*π")
                 // Implicit multiplication around π
                 .replace(Regex("(\\d)π"), "$1*π")
                 .replace(Regex("π(\\d)"), "π*$1")
@@ -589,7 +590,8 @@ class CalculatorViewModel(
                 else -> {}
             }
         }
-        return stack.lastOrNull()?.v ?: throw ArithmeticException("Empty expression")
+        if (stack.size != 1) throw ArithmeticException("Malformed expression")
+        return stack.last().v
     }
 
     private fun bigSqrt(a: BigDecimal): BigDecimal {

--- a/app/src/test/java/com/m3calculator/CalculatorViewModelTest.kt
+++ b/app/src/test/java/com/m3calculator/CalculatorViewModelTest.kt
@@ -1800,4 +1800,12 @@ class CalculatorViewModelTest {
         tapEquals()
         assertResult("0")
     }
+
+    @Test
+    fun percentTimesPi() {
+        // 50%π = 0.5 × π ≈ 1.570796327
+        tap("5", "0", "%", "π")
+        tapEquals()
+        assertExpression("1.570796327")
+    }
 }


### PR DESCRIPTION
Add %π → %*π sanitizer rule so 50%π correctly evaluates as 0.5×π instead of silently dropping the percent result. Also make evaluatePostfix throw when the stack has != 1 value, surfacing missing implicit multiplication patterns instead of returning silently wrong results.