### PR TITLE
Fix checksums workflow to create PR instead of pushing to protected branch

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -78,13 +78,23 @@ jobs:
           sed -i "s|<!-- sha1 -->.*<!-- /sha1 -->|<!-- sha1 -->\`${SHA1}\`<!-- /sha1 -->|" README.md
           sed -i "s|<!-- sha256 -->.*<!-- /sha256 -->|<!-- sha256 -->\`${SHA256}\`<!-- /sha256 -->|" README.md
 
-      - name: Commit updated checksums
+      - name: Create checksums PR
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           git config user.name "github-actions[bot]"
           git config user.email "github-actions[bot]@users.noreply.github.com"
+          BRANCH="chore/checksums-${{ steps.version.outputs.tag }}"
+          git checkout -b "$BRANCH"
           git add README.md
-          git diff --cached --quiet || git commit -m "Update checksums for ${{ steps.version.outputs.tag }}"
-          git push origin HEAD:${{ github.event.repository.default_branch }}
+          if ! git diff --cached --quiet; then
+            git commit -m "Update checksums for ${{ steps.version.outputs.tag }}"
+            git push origin "$BRANCH"
+            gh pr create \
+              --title "Update checksums for ${{ steps.version.outputs.tag }}" \
+              --body "Auto-generated PR to update README checksums after release build." \
+              --base "${{ github.event.repository.default_branch }}"
+          fi
 
       - name: Create GitHub Release
         uses: softprops/action-gh-release@v2


### PR DESCRIPTION
- Fix release workflow failing when trying to push checksum updates directly to the protected develop branch
- Workflow now creates a chore/checksums-<version> branch and opens a PR instead of pushing directly