### PR TITLE
Remove v1.1.1 build entry from F-Droid YAML

### DIFF
--- a/metadata/com.vagujhelyigergely.calculatorm3.yml
+++ b/metadata/com.vagujhelyigergely.calculatorm3.yml
@@ -5,19 +5,12 @@ AuthorName: Gergely Vagujhelyi
 SourceCode: https://github.com/gergelyvagujhelyi/CalculatorM3
 IssueTracker: https://github.com/gergelyvagujhelyi/CalculatorM3/issues
 
-AutoName: Calculator M3
+AutoName: Calculator
 
 RepoType: git
 Repo: https://github.com/gergelyvagujhelyi/CalculatorM3.git
 
 Builds:
-  - versionName: 1.1.1
-    versionCode: 3
-    commit: v1.1.1
-    subdir: app
-    gradle:
-      - yes
-
   - versionName: 1.2.0
     versionCode: 4
     commit: v1.2.0


### PR DESCRIPTION
The v1.1.1 tag used the old com.m3calculator package ID which doesn't match the current application ID, causing F-Droid build failures.