### PR TITLE
Feature/ieee 754 compatibility

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -32,8 +32,8 @@ android {
         applicationId = "com.vagujhelyigergely.calculatorm3"
         minSdk = 26
         targetSdk = 35
-        versionCode = 5
-        versionName = "1.2.1"
+        versionCode = 6
+        versionName = "1.3.0"
 
         testInstrumentationRunner = "androidx.test.runner.AndroidJUnitRunner"
 

--- a/app/src/androidTest/java/com/vagujhelyigergely/calculatorm3/CalculatorUiTest.kt
+++ b/app/src/androidTest/java/com/vagujhelyigergely/calculatorm3/CalculatorUiTest.kt
@@ -488,7 +488,7 @@ class CalculatorUiTest {
     fun piValue() {
         launch()
         tap("π", "=")
-        expressionShows("3.141592654")
+        expressionShows("3.1415926535")
     }
 
     @Test
@@ -910,7 +910,7 @@ class CalculatorUiTest {
     fun oneDividedBySeven() {
         launch()
         tap("1", "÷", "7", "=")
-        expressionShows("0.1428571429")
+        expressionShows("0.1428571428")
     }
 
     // ── Combined unary + binary (additional) ──────────────────────

--- a/app/src/main/java/com/vagujhelyigergely/calculatorm3/CalculatorViewModel.kt
+++ b/app/src/main/java/com/vagujhelyigergely/calculatorm3/CalculatorViewModel.kt
@@ -333,14 +333,15 @@ class CalculatorViewModel(
     private val MC = MathContext.DECIMAL128
     private val PI = BigDecimal("3.14159265358979323846264338327950288")
     private val HUNDRED = BigDecimal("100")
-    private val DISPLAY_PRECISION = MathContext(10, RoundingMode.HALF_UP)
+    private val RESULT_PRECISION = MathContext(30, RoundingMode.HALF_UP)
 
     /** Format a plain value string as E notation when it exceeds display width. */
     fun formatForDisplay(value: String): String {
         if (!value.startsWith("Error") && value.length > maxDisplayLength) {
             try {
                 val bd = BigDecimal(value)
-                val rounded = bd.round(DISPLAY_PRECISION).stripTrailingZeros()
+                val displayPrecision = MathContext((maxDisplayLength - 4).coerceIn(10, 30), RoundingMode.HALF_UP)
+                val rounded = bd.round(displayPrecision).stripTrailingZeros()
                 val eng = rounded.toEngineeringString()
                 // toEngineeringString may return plain for small integers (scale 0).
                 // In that case, build engineering notation manually.
@@ -404,7 +405,7 @@ class CalculatorViewModel(
             if (stripped.scale() <= 0) {
                 stripped.toBigInteger().toString()
             } else {
-                val formatted = result.round(DISPLAY_PRECISION).stripTrailingZeros()
+                val formatted = result.round(RESULT_PRECISION).stripTrailingZeros()
                 formatted.toPlainString()
             }
         } catch (e: ArithmeticException) {

--- a/app/src/test/java/com/vagujhelyigergely/calculatorm3/CalculatorViewModelTest.kt
+++ b/app/src/test/java/com/vagujhelyigergely/calculatorm3/CalculatorViewModelTest.kt
@@ -125,7 +125,7 @@ class CalculatorViewModelTest {
     fun piValue() {
         tap("π")
         tapEquals()
-        assertExpression("3.141592654")
+        assertExpression("3.14159265358979323846264338328")
     }
 
     @Test
@@ -797,14 +797,14 @@ class CalculatorViewModelTest {
     fun piTimesTwo() {
         tap("π", "×", "2")
         tapEquals()
-        assertExpression("6.283185307")
+        assertExpression("6.28318530717958647692528676656")
     }
 
     @Test
     fun twoTimesPi() {
         tap("2", "×", "π")
         tapEquals()
-        assertExpression("6.283185307")
+        assertExpression("6.28318530717958647692528676656")
     }
 
     @Test
@@ -957,7 +957,7 @@ class CalculatorViewModelTest {
     fun oneDividedBySeven() {
         tap("1", "÷", "7")
         tapEquals()
-        assertExpression("0.1428571429")
+        assertExpression("0.142857142857142857142857142857")
     }
 
     @Test
@@ -1173,7 +1173,7 @@ class CalculatorViewModelTest {
     @Test
     fun previewAfterPi() {
         tap("π")
-        assertResult("3.141592654")
+        assertResult("3.1415926535897932385")
     }
 
     @Test
@@ -1240,8 +1240,8 @@ class CalculatorViewModelTest {
     fun piTimesPi() {
         tap("π", "π")
         tapEquals()
-        // Should be π×π ≈ 9.869604401
-        assertExpression("9.869604401")
+        // Should be π×π ≈ 9.8696044...
+        assertExpression("9.86960440108935861883449099988")
     }
 
     // BUG: √(4)π drops the sqrt result because no implicit multiply
@@ -1250,10 +1250,10 @@ class CalculatorViewModelTest {
     // silently returns only the last value.
     @Test
     fun sqrtThenPiShouldMultiply() {
-        // √(4) × π should be 2π ≈ 6.283185307
+        // √(4) × π should be 2π ≈ 6.2831853...
         tap("4", "√", "π")
         tapEquals()
-        assertExpression("6.283185307")
+        assertExpression("6.28318530717958647692528676656")
     }
 
     // BUG: Preview showed stale result when evaluation fails.
@@ -1273,7 +1273,7 @@ class CalculatorViewModelTest {
         tapEquals()
         // Expression stores plain format; display shows E notation
         assert(!vm.expression.contains("E")) { "Expression should be plain, got: ${vm.expression}" }
-        assertEquals("265.2528598E+30", vm.displayExpression)
+        assertEquals("265.25285981219105864E+30", vm.displayExpression)
     }
 
     // BUG: A lone decimal point at the start produces "Error" because
@@ -1365,7 +1365,7 @@ class CalculatorViewModelTest {
         tapEquals()
         // Expression stores plain (no E), display shows E notation
         assert(!vm.expression.contains("E")) { "Expression should be plain: ${vm.expression}" }
-        assertEquals("265.2528598E+30", vm.displayExpression)
+        assertEquals("265.25285981219105864E+30", vm.displayExpression)
         // Backspace removes last digit of the plain number
         tap("⌫")
         assert(!vm.expression.contains("E")) { "After backspace, still plain: ${vm.expression}" }
@@ -1460,8 +1460,8 @@ class CalculatorViewModelTest {
         // Apply sqrt
         tap("√")
         tapEquals()
-        // √(100000) ≈ 316.227766
-        assertExpression("316.227766")
+        // √(100000) ≈ 316.2277660...
+        assertExpression("316.227766016837933199889354443")
     }
 
     // Large result: addition after large result
@@ -1803,9 +1803,9 @@ class CalculatorViewModelTest {
 
     @Test
     fun percentTimesPi() {
-        // 50%π = 0.5 × π ≈ 1.570796327
+        // 50%π = 0.5 × π ≈ 1.5707963...
         tap("5", "0", "%", "π")
         tapEquals()
-        assertExpression("1.570796327")
+        assertExpression("1.57079632679489661923132169164")
     }
 }

--- a/metadata/com.vagujhelyigergely.calculatorm3.yml
+++ b/metadata/com.vagujhelyigergely.calculatorm3.yml
@@ -13,9 +13,9 @@ Binaries:
   https://github.com/gergelyvagujhelyi/CalculatorM3/releases/download/v%v/app-release.apk
 
 Builds:
-  - versionName: 1.2.0
-    versionCode: 4
-    commit: d1adb6a10479eee19bd05c59282ffb3636b43bd3
+  - versionName: 1.3.0
+    versionCode: 6
+    commit: 58c645a9e79829822774067a46145cb4b4ff9ae5
     subdir: app
     gradle:
       - yes
@@ -24,5 +24,5 @@ AllowedAPKSigningKeys: 49646ed216aa6e8f23326999052f6704b6e9228be310b56b6e8b3ab81
 
 AutoUpdateMode: Version
 UpdateCheckMode: Tags
-CurrentVersion: 1.2.1
-CurrentVersionCode: 5
+CurrentVersion: 1.3.0
+CurrentVersionCode: 6


### PR DESCRIPTION
- Increased arithmetic result precision from 10 to 30 significant digits (DECIMAL128 uses 34 internally, leaving 4 guard digits to clean up rounding noise like 1÷3×3 = 1)                                                                                                                                                                                            
- Display precision is now dynamic based on screen width instead of fixed at 10 sig figs, showing as many digits as physically fit
- Fixes bug where adding a small number to a large number (e.g. 10^9 + 0.1) would silently drop the fractional part  