### PR TITLE
Feature/expression display scroll

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -32,8 +32,8 @@ android {
         applicationId = "com.vagujhelyigergely.calculatorm3"
         minSdk = 26
         targetSdk = 35
-        versionCode = 6
-        versionName = "1.3.0"
+        versionCode = 7
+        versionName = "1.4.0"
 
         testInstrumentationRunner = "androidx.test.runner.AndroidJUnitRunner"
 

--- a/app/src/androidTest/java/com/vagujhelyigergely/calculatorm3/CalculatorUiTest.kt
+++ b/app/src/androidTest/java/com/vagujhelyigergely/calculatorm3/CalculatorUiTest.kt
@@ -512,27 +512,27 @@ class CalculatorUiTest {
         expressionShows("9.869604401")
     }
 
-    // ── Division by zero ──────────────────────────────────────────
+    // ── IEEE 754 error messages ─────────────────────────────────────
 
     @Test
     fun divisionByZero() {
         launch()
         tap("5", "÷", "0", "=")
-        expressionShows("Error")
+        expressionShows("Error: divisionByZero")
     }
 
     @Test
     fun divisionByZeroInChain() {
         launch()
         tap("5", "+", "1", "0", "÷", "0", "=")
-        expressionShows("Error")
+        expressionShows("Error: divisionByZero")
     }
 
     @Test
     fun zeroByZero() {
         launch()
         tap("0", "÷", "0", "=")
-        expressionShows("Error")
+        expressionShows("Error: divisionByZero")
     }
 
     // ── Factorial (additional) ────────────────────────────────────
@@ -545,10 +545,10 @@ class CalculatorUiTest {
     }
 
     @Test
-    fun factorialAbove99ReturnsError() {
+    fun factorialAbove99ReturnsInvalidOperation() {
         launch()
         tap("1", "0", "0", "!", "=")
-        expressionShows("Error")
+        expressionShows("Error: invalidOperation")
     }
 
     @Test
@@ -598,10 +598,10 @@ class CalculatorUiTest {
     }
 
     @Test
-    fun sqrtOfNegativeReturnsError() {
+    fun sqrtOfNegativeReturnsInvalidOperation() {
         launch()
         tap("4", "+/−", "√", "=")
-        expressionShows("Error")
+        expressionShows("Error: invalidOperation")
     }
 
     @Test
@@ -949,5 +949,44 @@ class CalculatorUiTest {
         // .5 + 3 = 3.5
         tap(".", "5", "+", "3", "=")
         expressionShows("3.5")
+    }
+
+    // ── IEEE 754 overflow ────────────────────────────────────────────
+
+    @Test
+    fun overflowOnLargePower() {
+        launch()
+        // 9^9999 overflows Double → Error: overflow
+        tap("9", "^", "9", "9", "9", "9", "=")
+        expressionShows("Error: overflow")
+    }
+
+    // ── IEEE 754 error recovery ──────────────────────────────────────
+
+    @Test
+    fun newExpressionAfterDivisionByZero() {
+        launch()
+        tap("5", "÷", "0", "=")
+        expressionShows("Error: divisionByZero")
+        tap("3", "+", "2", "=")
+        expressionShows("5")
+    }
+
+    @Test
+    fun newExpressionAfterInvalidOperation() {
+        launch()
+        tap("4", "+/−", "√", "=")
+        expressionShows("Error: invalidOperation")
+        tap("9", "√", "=")
+        expressionShows("3")
+    }
+
+    @Test
+    fun newExpressionAfterOverflow() {
+        launch()
+        tap("9", "^", "9", "9", "9", "9", "=")
+        expressionShows("Error: overflow")
+        tap("2", "+", "3", "=")
+        expressionShows("5")
     }
 }

--- a/app/src/main/java/com/vagujhelyigergely/calculatorm3/CalculatorScreen.kt
+++ b/app/src/main/java/com/vagujhelyigergely/calculatorm3/CalculatorScreen.kt
@@ -32,6 +32,7 @@ import androidx.compose.ui.unit.IntOffset
 import androidx.compose.ui.hapticfeedback.HapticFeedbackType
 import androidx.compose.ui.platform.LocalHapticFeedback
 import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.text.rememberTextMeasurer
 import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.text.style.TextOverflow
 import android.content.res.Configuration
@@ -446,22 +447,11 @@ fun DisplaySection(
 
             Spacer(modifier = Modifier.height(8.dp))
 
-            // Expression with auto-sizing font
-            val displayText = formatted.ifEmpty { "0" }
-
+            // Expression with auto-sizing font — uses TextMeasurer to compute
+            // correct font size and front-trim in a single pass (no flicker)
             val fontSizeSteps = remember { listOf(56f, 46f, 38f, 32f, 28f) }
-            var fontStepIndex by remember { mutableIntStateOf(0) }
-            var readyToDraw by remember { mutableStateOf(true) }
+            val textMeasurer = rememberTextMeasurer()
 
-            // When expression gets shorter, try growing back to largest font
-            val prevExprLength = remember { mutableIntStateOf(0) }
-            if (expression.length < prevExprLength.intValue && fontStepIndex > 0) {
-                fontStepIndex = 0
-                readyToDraw = false
-            }
-            prevExprLength.intValue = expression.length
-
-            val currentFontSize = fontSizeSteps[fontStepIndex]
             val cursorVisible = cursorPosition < expression.length && expression.isNotEmpty()
 
             val textLayoutResult = remember { mutableStateOf<androidx.compose.ui.text.TextLayoutResult?>(null) }
@@ -485,7 +475,77 @@ fun DisplaySection(
                 alpha > 0.5f
             } else false
 
-            Box(modifier = Modifier.fillMaxWidth()) {
+            BoxWithConstraints(modifier = Modifier.fillMaxWidth()) {
+                val rawText = formatted.ifEmpty { "0" }
+                val measureConstraints = androidx.compose.ui.unit.Constraints(
+                    maxWidth = constraints.maxWidth
+                )
+
+                // Find largest font that fits in 2 lines
+                fun makeStyle(step: Int) = androidx.compose.ui.text.TextStyle(
+                    fontSize = fontSizeSteps[step].sp,
+                    fontWeight = FontWeight.Light,
+                    lineHeight = (fontSizeSteps[step] * 1.15f).sp,
+                    letterSpacing = (-0.5).sp,
+                )
+
+                var bestStep = fontSizeSteps.lastIndex
+                for (i in fontSizeSteps.indices) {
+                    val result = textMeasurer.measure(
+                        text = androidx.compose.ui.text.AnnotatedString(rawText),
+                        style = makeStyle(i),
+                        constraints = measureConstraints,
+                        maxLines = 2,
+                        overflow = TextOverflow.Ellipsis
+                    )
+                    if (!result.hasVisualOverflow) {
+                        bestStep = i
+                        break
+                    }
+                }
+
+                // If at smallest font and still overflows, trim from front
+                var bestTrim = 0
+                if (bestStep == fontSizeSteps.lastIndex) {
+                    val style = makeStyle(bestStep)
+                    val fullResult = textMeasurer.measure(
+                        text = androidx.compose.ui.text.AnnotatedString(rawText),
+                        style = style,
+                        constraints = measureConstraints,
+                        maxLines = 2,
+                        overflow = TextOverflow.Ellipsis
+                    )
+                    if (fullResult.hasVisualOverflow) {
+                        // Estimate how many chars are hidden
+                        val visibleEnd = fullResult.getLineEnd(
+                            fullResult.lineCount - 1, true
+                        )
+                        val excess = rawText.length - visibleEnd
+                        bestTrim = (excess + 2).coerceAtLeast(1)
+
+                        // Fine-tune until it fits
+                        while (bestTrim < rawText.length) {
+                            val trimmedText = "… " + rawText.drop(bestTrim)
+                            val trimResult = textMeasurer.measure(
+                                text = androidx.compose.ui.text.AnnotatedString(trimmedText),
+                                style = style,
+                                constraints = measureConstraints,
+                                maxLines = 2,
+                                overflow = TextOverflow.Ellipsis
+                            )
+                            if (!trimResult.hasVisualOverflow) break
+                            bestTrim++
+                        }
+                    }
+                }
+
+                val displayText = if (bestTrim > 0 && rawText.length > bestTrim) {
+                    "… " + rawText.drop(bestTrim)
+                } else {
+                    rawText
+                }
+                val currentFontSize = fontSizeSteps[bestStep]
+
                 Text(
                     text = displayText,
                     fontSize = currentFontSize.sp,
@@ -498,33 +558,30 @@ fun DisplaySection(
                     letterSpacing = (-0.5).sp,
                     onTextLayout = { result ->
                         textLayoutResult.value = result
-                        if (result.hasVisualOverflow && fontStepIndex < fontSizeSteps.lastIndex) {
-                            fontStepIndex++
-                            readyToDraw = false
-                        } else {
-                            readyToDraw = true
-                        }
                     },
                     modifier = Modifier
                         .fillMaxWidth()
-                        .graphicsLayer { alpha = if (readyToDraw) 1f else 0f }
-                        .pointerInput(displayText) {
+                        .pointerInput(displayText, bestTrim) {
                             detectTapGestures { offset ->
                                 textLayoutResult.value?.let { layout ->
                                     val tappedOffset = layout.getOffsetForPosition(offset)
-                                    val rawCursor = mapCursorFromFormatted(expression, tappedOffset)
+                                    val adjustedOffset = if (bestTrim > 0) {
+                                        (tappedOffset + bestTrim - 2).coerceAtLeast(0)
+                                    } else tappedOffset
+                                    val rawCursor = mapCursorFromFormatted(expression, adjustedOffset)
                                     onCursorChange(rawCursor)
                                 }
                             }
                         }
                 )
 
-                if (cursorVisible && blinkVisible && readyToDraw) {
+                if (cursorVisible && blinkVisible) {
                     textLayoutResult.value?.let { layout ->
-                        // Coerce to the layout's actual text length to avoid crash
-                        // when the layout is stale (not yet updated for the new expression)
                         val layoutLen = layout.layoutInput.text.length
-                        val cursorOffset = cursorInFormatted.coerceIn(0, layoutLen)
+                        val adjustedCursor = if (bestTrim > 0) {
+                            (cursorInFormatted - bestTrim + 2).coerceAtLeast(0)
+                        } else cursorInFormatted
+                        val cursorOffset = adjustedCursor.coerceIn(0, layoutLen)
                         val cursorRect = layout.getCursorRect(cursorOffset)
                         Box(
                             modifier = Modifier

--- a/app/src/main/java/com/vagujhelyigergely/calculatorm3/CalculatorViewModel.kt
+++ b/app/src/main/java/com/vagujhelyigergely/calculatorm3/CalculatorViewModel.kt
@@ -410,15 +410,15 @@ class CalculatorViewModel(
             }
         } catch (e: ArithmeticException) {
             when {
-                e.message?.contains("Division by zero") == true -> "Error: ÷ by 0"
-                e.message?.contains("Negative sqrt") == true -> "Error: √ of neg"
-                e.message?.contains("Invalid factorial") == true -> "Error: bad n!"
+                e.message?.contains("Division by zero") == true -> "Error: divisionByZero"
+                e.message?.contains("Negative sqrt") == true -> "Error: invalidOperation"
+                e.message?.contains("Invalid factorial") == true -> "Error: invalidOperation"
                 e.message?.contains("Non-finite") == true -> "Error: overflow"
-                e.message?.contains("Nesting too deep") == true -> "Error: too nested"
-                else -> "Error"
+                e.message?.contains("Nesting too deep") == true -> "Error: invalidOperation"
+                else -> "Error: invalidOperation"
             }
         } catch (_: Exception) {
-            "Error"
+            "Error: invalidOperation"
         }
     }
 

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -1,14 +1,11 @@
 <resources>
     <string name="app_name">Calculator</string>
 
-    <!-- Error messages -->
+    <!-- IEEE 754 standard error messages -->
     <string name="error">Error</string>
-    <string name="error_division_by_zero">Can\'t divide by zero</string>
-    <string name="error_negative_sqrt">Can\'t take √ of negative</string>
-    <string name="error_invalid_factorial">Invalid factorial</string>
-    <string name="error_overflow">Overflow</string>
-    <string name="error_too_nested">Expression too nested</string>
-    <string name="error_invalid_input">Invalid input</string>
+    <string name="error_division_by_zero">divisionByZero</string>
+    <string name="error_invalid_operation">invalidOperation</string>
+    <string name="error_overflow">overflow</string>
 
     <!-- History -->
     <string name="history">History</string>

--- a/app/src/test/java/com/vagujhelyigergely/calculatorm3/CalculatorViewModelTest.kt
+++ b/app/src/test/java/com/vagujhelyigergely/calculatorm3/CalculatorViewModelTest.kt
@@ -187,7 +187,7 @@ class CalculatorViewModelTest {
     fun divisionByZero() {
         tap("5", "÷", "0")
         tapEquals()
-        assertResult("Error: ÷ by 0")
+        assertResult("Error: divisionByZero")
         assertExpression("")
     }
 
@@ -391,7 +391,7 @@ class CalculatorViewModelTest {
         // 100! exceeds the limit
         tap("1", "0", "0", "!")
         tapEquals()
-        assertResult("Error: bad n!")
+        assertResult("Error: invalidOperation")
         assertExpression("")
     }
 
@@ -485,7 +485,7 @@ class CalculatorViewModelTest {
         tap("+/−")
         tap("√")
         tapEquals()
-        assertResult("Error: √ of neg")
+        assertResult("Error: invalidOperation")
         assertExpression("")
     }
 
@@ -720,7 +720,7 @@ class CalculatorViewModelTest {
         // 5÷0=Error, then 3+2=5
         tap("5", "÷", "0")
         tapEquals()
-        assertResult("Error: ÷ by 0")
+        assertResult("Error: divisionByZero")
         assertExpression("")
         tap("3", "+", "2")
         tapEquals()
@@ -902,7 +902,7 @@ class CalculatorViewModelTest {
         // 5 + 10÷0 = Error
         tap("5", "+", "1", "0", "÷", "0")
         tapEquals()
-        assertResult("Error: ÷ by 0")
+        assertResult("Error: divisionByZero")
         assertExpression("")
     }
 
@@ -910,7 +910,7 @@ class CalculatorViewModelTest {
     fun zeroByZero() {
         tap("0", "÷", "0")
         tapEquals()
-        assertResult("Error: ÷ by 0")
+        assertResult("Error: divisionByZero")
         assertExpression("")
     }
 
@@ -1729,7 +1729,7 @@ class CalculatorViewModelTest {
         tap("4")
         repeat(21) { tap("√") }
         tapEquals()
-        assertResult("Error: too nested")
+        assertResult("Error: invalidOperation")
         assertExpression("")
     }
 
@@ -1743,13 +1743,13 @@ class CalculatorViewModelTest {
         assert(!vm.result.startsWith("Error")) { "Should succeed at depth 20, got: ${vm.result}" }
     }
 
-    // ── Specific error messages ───────────────────────────────────────
+    // ── IEEE 754 error messages ────────────────────────────────────────
 
     @Test
     fun divisionByZeroMessage() {
         tap("1", "÷", "0")
         tapEquals()
-        assertResult("Error: ÷ by 0")
+        assertResult("Error: divisionByZero")
     }
 
     @Test
@@ -1758,14 +1758,22 @@ class CalculatorViewModelTest {
         tap("+/−")
         tap("√")
         tapEquals()
-        assertResult("Error: √ of neg")
+        assertResult("Error: invalidOperation")
     }
 
     @Test
     fun invalidFactorialMessage() {
         tap("1", "0", "0", "!")
         tapEquals()
-        assertResult("Error: bad n!")
+        assertResult("Error: invalidOperation")
+    }
+
+    @Test
+    fun overflowMessage() {
+        // 9^9999 overflows Double → Non-finite
+        tap("9", "^", "9", "9", "9", "9")
+        tapEquals()
+        assertResult("Error: overflow")
     }
 
     // --- Implicit multiply before √ ---

--- a/metadata/com.vagujhelyigergely.calculatorm3.yml
+++ b/metadata/com.vagujhelyigergely.calculatorm3.yml
@@ -13,9 +13,9 @@ Binaries:
   https://github.com/gergelyvagujhelyi/CalculatorM3/releases/download/v%v/app-release.apk
 
 Builds:
-  - versionName: 1.3.0
-    versionCode: 6
-    commit: 58c645a9e79829822774067a46145cb4b4ff9ae5
+  - versionName: 1.4.0
+    versionCode: 7
+    commit: TBD
     subdir: app
     gradle:
       - yes
@@ -24,5 +24,5 @@ AllowedAPKSigningKeys: 49646ed216aa6e8f23326999052f6704b6e9228be310b56b6e8b3ab81
 
 AutoUpdateMode: Version
 UpdateCheckMode: Tags
-CurrentVersion: 1.3.0
-CurrentVersionCode: 6
+CurrentVersion: 1.4.0
+CurrentVersionCode: 7

--- a/metadata/en-US/changelogs/2.txt
+++ b/metadata/en-US/changelogs/2.txt
@@ -1,4 +1,7 @@
-- Fix implicit multiply with % and π
-- Reject malformed postfix expressions
-- Production readiness improvements
-- Calculator bug fixes and UI polish
+- Add landscape layout with side-by-side display and button grid
+- Persist calculator state across process death
+- Persist calculation history across app restarts
+- Operator replacement when typing consecutive operators
+- Fix +/− to toggle sign of current operand, not whole expression
+- Consumer-style percentage semantics with + and −
+- Production readiness improvements and bug fixes

--- a/metadata/en-US/changelogs/3.txt
+++ b/metadata/en-US/changelogs/3.txt
@@ -1,4 +1,6 @@
 - Add foldable device support (Pixel 9 Pro Fold, Galaxy Z Fold)
 - Adaptive layout for near-square screens
+- Fix implicit multiply with %π
+- Add GNU GPL v3 license
 - Redesigned README with screenshots
 - Auto-generate checksums in GitHub releases

--- a/metadata/en-US/changelogs/5.txt
+++ b/metadata/en-US/changelogs/5.txt
@@ -1,0 +1,5 @@
+- Add Google Play integration with automated AAB deployment
+- Add privacy policy page
+- Fix F-Droid reproducible build issues
+- Exclude version-control-info.textproto for build reproducibility
+- Fix Binaries formatting in F-Droid metadata

--- a/metadata/en-US/changelogs/6.txt
+++ b/metadata/en-US/changelogs/6.txt
@@ -1,0 +1,2 @@
+- Increase arithmetic precision to 30 significant digits for IEEE 754 compatibility
+- Dynamic display precision based on screen width

--- a/metadata/en-US/changelogs/7.txt
+++ b/metadata/en-US/changelogs/7.txt
@@ -1,0 +1,3 @@
+- Show end of long expressions instead of truncating with ellipsis
+- Flicker-free display using single-pass TextMeasurer
+- IEEE 754 standard error messages (divisionByZero, invalidOperation, overflow)


### PR DESCRIPTION
- Long expressions now show the end (most recently typed characters) instead of truncating with "..." — uses single-pass TextMeasurer to eliminate flickering on delete and line changes
- Error messages use IEEE 754 standard exception names: divisionByZero, invalidOperation, overflow
- Bump version to 1.4.0 (versionCode 7) with updated F-Droid metadata and corrected changelogs for all versions