### PR TITLE
Bugfix/expression display wrapping

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -32,8 +32,8 @@ android {
         applicationId = "com.vagujhelyigergely.calculatorm3"
         minSdk = 26
         targetSdk = 35
-        versionCode = 9
-        versionName = "1.4.2"
+        versionCode = 10
+        versionName = "1.4.3"
 
         testInstrumentationRunner = "androidx.test.runner.AndroidJUnitRunner"
 

--- a/app/src/main/java/com/vagujhelyigergely/calculatorm3/CalculatorScreen.kt
+++ b/app/src/main/java/com/vagujhelyigergely/calculatorm3/CalculatorScreen.kt
@@ -488,18 +488,24 @@ fun DisplaySection(
             BoxWithConstraints(modifier = Modifier.fillMaxWidth()) {
                 val rawText = formatted.ifEmpty { "0" }
                 val maxWidthPx = constraints.maxWidth
+                val baseTextStyle = LocalTextStyle.current
 
                 // Cache measurement results — only recompute when text or width changes
-                val (bestStep, bestTrim) = remember(rawText, maxWidthPx) {
+                val (bestStep, bestTrim) = remember(rawText, maxWidthPx, baseTextStyle) {
                     val measureConstraints = androidx.compose.ui.unit.Constraints(
                         maxWidth = maxWidthPx
                     )
 
-                    fun makeStyle(step: Int) = androidx.compose.ui.text.TextStyle(
-                        fontSize = fontSizeSteps[step].sp,
-                        fontWeight = FontWeight.Light,
-                        lineHeight = (fontSizeSteps[step] * 1.15f).sp,
-                        letterSpacing = (-0.5).sp,
+                    // Merge with LocalTextStyle so the measurement uses the same
+                    // font family and platform style as the Text composable
+                    fun makeStyle(step: Int) = baseTextStyle.merge(
+                        androidx.compose.ui.text.TextStyle(
+                            fontSize = fontSizeSteps[step].sp,
+                            fontWeight = FontWeight.Light,
+                            lineHeight = (fontSizeSteps[step] * 1.15f).sp,
+                            letterSpacing = (-0.5).sp,
+                            textAlign = TextAlign.End,
+                        )
                     )
 
                     // Find largest font that fits in 2 lines

--- a/metadata/com.vagujhelyigergely.calculatorm3.yml
+++ b/metadata/com.vagujhelyigergely.calculatorm3.yml
@@ -20,8 +20,8 @@ Builds:
     gradle:
       - yes
 
-  - versionName: 1.4.2
-    versionCode: 9
+  - versionName: 1.4.3
+    versionCode: 10
     commit: TBD
     subdir: app
     gradle:
@@ -31,5 +31,5 @@ AllowedAPKSigningKeys: 49646ed216aa6e8f23326999052f6704b6e9228be310b56b6e8b3ab81
 
 AutoUpdateMode: Version
 UpdateCheckMode: Tags
-CurrentVersion: 1.4.2
-CurrentVersionCode: 9
+CurrentVersion: 1.4.3
+CurrentVersionCode: 10

--- a/metadata/en-US/changelogs/10.txt
+++ b/metadata/en-US/changelogs/10.txt
@@ -1,0 +1,1 @@
+- Fix expression wrapping on Samsung devices (e.g. S25) after continuing from a large result


### PR DESCRIPTION
- Fix expression staying on 1 line with ellipsis instead of wrapping to 2 lines on Samsung devices (e.g. S25) when continuing a calculation from a large result (e.g. 9^9 = then + number)
- Root cause: the TextMeasurer pre-measurement created a bare TextStyle that didn't inherit LocalTextStyle.current, causing a font metric mismatch on devices with custom system fonts (Samsung uses SamsungOne instead of Roboto)
- Bump version to 1.4.3, add changelog, update F-Droid metadata