### PR TITLE
Bugfix/expression display wrapping

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -32,8 +32,8 @@ android {
         applicationId = "com.vagujhelyigergely.calculatorm3"
         minSdk = 26
         targetSdk = 35
-        versionCode = 9
-        versionName = "1.4.2"
+        versionCode = 10
+        versionName = "1.4.3"
 
         testInstrumentationRunner = "androidx.test.runner.AndroidJUnitRunner"
 

--- a/app/src/main/java/com/vagujhelyigergely/calculatorm3/CalculatorScreen.kt
+++ b/app/src/main/java/com/vagujhelyigergely/calculatorm3/CalculatorScreen.kt
@@ -490,7 +490,7 @@ fun DisplaySection(
                 val maxWidthPx = constraints.maxWidth
 
                 // Cache measurement results — only recompute when text or width changes
-                val (bestStep, bestTrim) = remember(rawText, maxWidthPx) {
+                val (estimatedStep, bestTrim) = remember(rawText, maxWidthPx) {
                     val measureConstraints = androidx.compose.ui.unit.Constraints(
                         maxWidth = maxWidthPx
                     )
@@ -502,7 +502,7 @@ fun DisplaySection(
                         letterSpacing = (-0.5).sp,
                     )
 
-                    // Find largest font that fits in 2 lines
+                    // Find largest font that fits in 2 lines (best-effort estimate)
                     var step = fontSizeSteps.lastIndex
                     for (i in fontSizeSteps.indices) {
                         val result = textMeasurer.measure(
@@ -557,6 +557,13 @@ fun DisplaySection(
                     step to trim
                 }
 
+                // onTextLayout correction: TextMeasurer can disagree with the
+                // actual Text composable on some OEMs (e.g. Samsung One UI).
+                // Start from the TextMeasurer estimate and let onTextLayout
+                // step down further if the real rendering still overflows.
+                var fontCorrection by remember(rawText) { mutableIntStateOf(0) }
+                val bestStep = (estimatedStep + fontCorrection).coerceAtMost(fontSizeSteps.lastIndex)
+
                 val displayText = if (bestTrim > 0 && rawText.length > bestTrim) {
                     "… " + rawText.drop(bestTrim)
                 } else {
@@ -578,6 +585,9 @@ fun DisplaySection(
                     letterSpacing = (-0.5).sp,
                     onTextLayout = { result ->
                         textLayoutResult.value = result
+                        if (result.hasVisualOverflow && bestStep < fontSizeSteps.lastIndex) {
+                            fontCorrection++
+                        }
                     },
                     modifier = Modifier
                         .fillMaxWidth()

--- a/metadata/com.vagujhelyigergely.calculatorm3.yml
+++ b/metadata/com.vagujhelyigergely.calculatorm3.yml
@@ -20,8 +20,8 @@ Builds:
     gradle:
       - yes
 
-  - versionName: 1.4.2
-    versionCode: 9
+  - versionName: 1.4.3
+    versionCode: 10
     commit: TBD
     subdir: app
     gradle:
@@ -31,5 +31,5 @@ AllowedAPKSigningKeys: 49646ed216aa6e8f23326999052f6704b6e9228be310b56b6e8b3ab81
 
 AutoUpdateMode: Version
 UpdateCheckMode: Tags
-CurrentVersion: 1.4.2
-CurrentVersionCode: 9
+CurrentVersion: 1.4.3
+CurrentVersionCode: 10

--- a/metadata/en-US/changelogs/10.txt
+++ b/metadata/en-US/changelogs/10.txt
@@ -1,0 +1,1 @@
+- Fix expression wrapping on Samsung devices (e.g. S25) after continuing from a large result


### PR DESCRIPTION
- Fix expression staying on 1 line with ellipsis instead of wrapping to 2 lines on Samsung devices (e.g. S25) when continuing a calculation from a large result (e.g. 9^9 = then + number)
- Root cause: Samsung One UI's text rendering engine disagrees with Compose's TextMeasurer at a platform level, causing the pre-measurement to select a font size where the expression overflows
- Fix: keep TextMeasurer as a flicker-free initial estimate, but add onTextLayout from the actual Text composable as the authority — if the real rendering overflows, fontCorrection steps down the font size until it fits
- Bump version to 1.4.3, add changelog, update F-Droid metadata