### PR TITLE
Feature/thousand separators

### DIFF
--- a/app/src/main/java/com/vagujhelyigergely/calculatorm3/CalculatorScreen.kt
+++ b/app/src/main/java/com/vagujhelyigergely/calculatorm3/CalculatorScreen.kt
@@ -910,7 +910,7 @@ fun HistorySheet(
     }
 }
 
-private fun formatExpression(expr: String): String {
+internal fun formatExpression(expr: String): String {
     val sb = StringBuilder()
     var i = 0
     while (i < expr.length) {
@@ -963,7 +963,7 @@ private fun formatExpression(expr: String): String {
     return sb.toString()
 }
 
-private fun formatResultNumber(value: String): String {
+internal fun formatResultNumber(value: String): String {
     if (value.isEmpty() || value.startsWith("Error") || value.contains('E') || value.contains('e')) return value
     val negative = value.startsWith("-")
     val abs = if (negative) value.substring(1) else value
@@ -980,7 +980,7 @@ private fun formatResultNumber(value: String): String {
     return (if (negative) "-" else "") + formatted + rest
 }
 
-private fun mapCursorToFormatted(raw: String, rawCursor: Int): Int {
+internal fun mapCursorToFormatted(raw: String, rawCursor: Int): Int {
     var fPos = 0
     var i = 0
     val limit = rawCursor.coerceAtMost(raw.length)
@@ -1015,7 +1015,7 @@ private fun mapCursorToFormatted(raw: String, rawCursor: Int): Int {
     return fPos
 }
 
-private fun mapCursorFromFormatted(raw: String, formattedCursor: Int): Int {
+internal fun mapCursorFromFormatted(raw: String, formattedCursor: Int): Int {
     var fPos = 0
     var i = 0
     while (i < raw.length && fPos < formattedCursor) {

--- a/app/src/main/java/com/vagujhelyigergely/calculatorm3/CalculatorScreen.kt
+++ b/app/src/main/java/com/vagujhelyigergely/calculatorm3/CalculatorScreen.kt
@@ -910,6 +910,11 @@ fun HistorySheet(
     }
 }
 
+private val BINARY_OPERATORS = setOf('+', '×', '÷', '−')
+
+private fun needsSeparator(indexInIntPart: Int, intPartLength: Int): Boolean =
+    indexInIntPart > 0 && (intPartLength - indexInIntPart) % 3 == 0
+
 internal fun formatExpression(expr: String): String {
     val sb = StringBuilder()
     var i = 0
@@ -922,7 +927,7 @@ internal fun formatExpression(expr: String): String {
                 while (i < expr.length && expr[i].isDigit()) i++
                 val intPart = expr.substring(intStart, i)
                 for (j in intPart.indices) {
-                    if (j > 0 && (intPart.length - j) % 3 == 0) sb.append(',')
+                    if (needsSeparator(j, intPart.length)) sb.append(',')
                     sb.append(intPart[j])
                 }
                 // Decimal part (no separators)
@@ -950,7 +955,7 @@ internal fun formatExpression(expr: String): String {
             }
             // Binary operators: space around them (not at position 0).
             // ASCII '-' (from +/− toggle) is unary, excluded from this set.
-            c in setOf('+', '×', '÷', '−') && sb.isNotEmpty() -> {
+            c in BINARY_OPERATORS && sb.isNotEmpty() -> {
                 sb.append(" $c ")
                 i++
             }
@@ -973,7 +978,7 @@ internal fun formatResultNumber(value: String): String {
     val rest = if (dotIndex >= 0) abs.substring(dotIndex) else ""
     val formatted = buildString {
         for (j in intPart.indices) {
-            if (j > 0 && (intPart.length - j) % 3 == 0) append(',')
+            if (needsSeparator(j, intPart.length)) append(',')
             append(intPart[j])
         }
     }
@@ -994,7 +999,7 @@ internal fun mapCursorToFormatted(raw: String, rawCursor: Int): Int {
                 val intLen = intEnd - intStart
                 val intLimit = limit.coerceAtMost(intEnd)
                 for (j in i until intLimit) {
-                    if (j - intStart > 0 && (intLen - (j - intStart)) % 3 == 0) fPos++
+                    if (needsSeparator(j - intStart, intLen)) fPos++
                     fPos++
                 }
                 i = intLimit
@@ -1008,7 +1013,7 @@ internal fun mapCursorToFormatted(raw: String, rawCursor: Int): Int {
                     while (i < limit && i < raw.length && raw[i].isDigit()) { fPos++; i++ }
                 }
             }
-            c in listOf('+', '−', '×', '÷') && i > 0 -> { fPos += 3; i++ }
+            c in BINARY_OPERATORS && i > 0 -> { fPos += 3; i++ }
             else -> { fPos++; i++ }
         }
     }
@@ -1028,7 +1033,7 @@ internal fun mapCursorFromFormatted(raw: String, formattedCursor: Int): Int {
                 val intLen = intEnd - intStart
                 while (i < intEnd && fPos < formattedCursor) {
                     val posInInt = i - intStart
-                    if (posInInt > 0 && (intLen - posInInt) % 3 == 0) {
+                    if (needsSeparator(posInInt, intLen)) {
                         fPos++
                         if (fPos >= formattedCursor) break
                     }
@@ -1044,7 +1049,7 @@ internal fun mapCursorFromFormatted(raw: String, formattedCursor: Int): Int {
                     while (i < raw.length && raw[i].isDigit() && fPos < formattedCursor) { fPos++; i++ }
                 }
             }
-            c in listOf('+', '−', '×', '÷') && i > 0 -> { fPos += 3; i++ }
+            c in BINARY_OPERATORS && i > 0 -> { fPos += 3; i++ }
             else -> { fPos++; i++ }
         }
     }

--- a/app/src/main/java/com/vagujhelyigergely/calculatorm3/CalculatorScreen.kt
+++ b/app/src/main/java/com/vagujhelyigergely/calculatorm3/CalculatorScreen.kt
@@ -455,7 +455,7 @@ fun DisplaySection(
                                 modifier = Modifier.fillMaxWidth()
                             )
                             Text(
-                                text = "= ${entry.result}",
+                                text = "= ${formatResultNumber(entry.result)}",
                                 style = MaterialTheme.typography.titleSmall,
                                 fontWeight = FontWeight.Medium,
                                 color = colorScheme.onSurfaceVariant,
@@ -482,7 +482,7 @@ fun DisplaySection(
                 exit = fadeOut()
             ) {
                 Text(
-                    text = history,
+                    text = formatExpression(history),
                     style = MaterialTheme.typography.bodyMedium,
                     color = colorScheme.outline,
                     textAlign = TextAlign.End,
@@ -679,7 +679,7 @@ fun DisplaySection(
             exit = fadeOut(animationSpec = tween(150))
         ) {
             Text(
-                text = if (result.startsWith("Error")) result else "= $result",
+                text = if (result.startsWith("Error")) result else "= ${formatResultNumber(result)}",
                 style = MaterialTheme.typography.headlineSmall,
                 color = colorScheme.primary.copy(alpha = 0.65f),
                 fontWeight = FontWeight.Medium,
@@ -894,7 +894,7 @@ fun HistorySheet(
                                 )
                                 Spacer(modifier = Modifier.height(2.dp))
                                 Text(
-                                    text = "= ${entry.result}",
+                                    text = "= ${formatResultNumber(entry.result)}",
                                     style = MaterialTheme.typography.titleMedium,
                                     fontWeight = FontWeight.Medium,
                                     color = colorScheme.onSurface,
@@ -911,35 +911,142 @@ fun HistorySheet(
 }
 
 private fun formatExpression(expr: String): String {
-    // Add spaces around binary operators (Unicode −, ×, ÷, and ASCII +).
-    // ASCII '-' (from +/− toggle or history load) is always a unary sign prefix,
-    // so it must NOT get spaces — otherwise cursor mapping breaks.
-    // Also skip the sign in E notation (e.g. E+30).
-    return expr.replace(Regex("(?<=.)(?<![Ee])[+×÷−]")) { " ${it.value} " }
+    val sb = StringBuilder()
+    var i = 0
+    while (i < expr.length) {
+        val c = expr[i]
+        when {
+            c.isDigit() || (c == '.' && i + 1 < expr.length && expr[i + 1].isDigit()) -> {
+                // Integer part — collect digits and add thousand separators
+                val intStart = i
+                while (i < expr.length && expr[i].isDigit()) i++
+                val intPart = expr.substring(intStart, i)
+                for (j in intPart.indices) {
+                    if (j > 0 && (intPart.length - j) % 3 == 0) sb.append(',')
+                    sb.append(intPart[j])
+                }
+                // Decimal part (no separators)
+                if (i < expr.length && expr[i] == '.') {
+                    sb.append('.')
+                    i++
+                    while (i < expr.length && expr[i].isDigit()) {
+                        sb.append(expr[i])
+                        i++
+                    }
+                }
+                // E notation suffix (pass through)
+                if (i < expr.length && (expr[i] == 'E' || expr[i] == 'e')) {
+                    sb.append(expr[i])
+                    i++
+                    if (i < expr.length && (expr[i] == '+' || expr[i] == '-')) {
+                        sb.append(expr[i])
+                        i++
+                    }
+                    while (i < expr.length && expr[i].isDigit()) {
+                        sb.append(expr[i])
+                        i++
+                    }
+                }
+            }
+            // Binary operators: space around them (not at position 0).
+            // ASCII '-' (from +/− toggle) is unary, excluded from this set.
+            c in setOf('+', '×', '÷', '−') && sb.isNotEmpty() -> {
+                sb.append(" $c ")
+                i++
+            }
+            else -> {
+                sb.append(c)
+                i++
+            }
+        }
+    }
+    return sb.toString()
+}
+
+private fun formatResultNumber(value: String): String {
+    if (value.isEmpty() || value.startsWith("Error") || value.contains('E') || value.contains('e')) return value
+    val negative = value.startsWith("-")
+    val abs = if (negative) value.substring(1) else value
+    val dotIndex = abs.indexOf('.')
+    val intPart = if (dotIndex >= 0) abs.substring(0, dotIndex) else abs
+    if (intPart.length <= 3) return value
+    val rest = if (dotIndex >= 0) abs.substring(dotIndex) else ""
+    val formatted = buildString {
+        for (j in intPart.indices) {
+            if (j > 0 && (intPart.length - j) % 3 == 0) append(',')
+            append(intPart[j])
+        }
+    }
+    return (if (negative) "-" else "") + formatted + rest
 }
 
 private fun mapCursorToFormatted(raw: String, rawCursor: Int): Int {
-    var formattedPos = 0
-    for (i in 0 until rawCursor.coerceAtMost(raw.length)) {
-        if (raw[i] in listOf('+', '−', '×', '÷')) {
-            formattedPos += 3 // " X "
-        } else {
-            formattedPos += 1
+    var fPos = 0
+    var i = 0
+    val limit = rawCursor.coerceAtMost(raw.length)
+    while (i < limit) {
+        val c = raw[i]
+        when {
+            c.isDigit() || (c == '.' && i + 1 < raw.length && raw[i + 1].isDigit()) -> {
+                val intStart = i
+                var intEnd = i
+                while (intEnd < raw.length && raw[intEnd].isDigit()) intEnd++
+                val intLen = intEnd - intStart
+                val intLimit = limit.coerceAtMost(intEnd)
+                for (j in i until intLimit) {
+                    if (j - intStart > 0 && (intLen - (j - intStart)) % 3 == 0) fPos++
+                    fPos++
+                }
+                i = intLimit
+                if (i == intEnd && i < limit && i < raw.length && raw[i] == '.') {
+                    fPos++; i++
+                    while (i < limit && i < raw.length && raw[i].isDigit()) { fPos++; i++ }
+                }
+                if (i < limit && i < raw.length && (raw[i] == 'E' || raw[i] == 'e')) {
+                    fPos++; i++
+                    if (i < limit && i < raw.length && (raw[i] == '+' || raw[i] == '-')) { fPos++; i++ }
+                    while (i < limit && i < raw.length && raw[i].isDigit()) { fPos++; i++ }
+                }
+            }
+            c in listOf('+', '−', '×', '÷') && i > 0 -> { fPos += 3; i++ }
+            else -> { fPos++; i++ }
         }
     }
-    return formattedPos
+    return fPos
 }
 
 private fun mapCursorFromFormatted(raw: String, formattedCursor: Int): Int {
     var fPos = 0
-    var rPos = 0
-    while (rPos < raw.length && fPos < formattedCursor) {
-        if (raw[rPos] in listOf('+', '−', '×', '÷')) {
-            fPos += 3
-        } else {
-            fPos += 1
+    var i = 0
+    while (i < raw.length && fPos < formattedCursor) {
+        val c = raw[i]
+        when {
+            c.isDigit() || (c == '.' && i + 1 < raw.length && raw[i + 1].isDigit()) -> {
+                val intStart = i
+                var intEnd = i
+                while (intEnd < raw.length && raw[intEnd].isDigit()) intEnd++
+                val intLen = intEnd - intStart
+                while (i < intEnd && fPos < formattedCursor) {
+                    val posInInt = i - intStart
+                    if (posInInt > 0 && (intLen - posInInt) % 3 == 0) {
+                        fPos++
+                        if (fPos >= formattedCursor) break
+                    }
+                    fPos++; i++
+                }
+                if (i == intEnd && i < raw.length && raw[i] == '.' && fPos < formattedCursor) {
+                    fPos++; i++
+                    while (i < raw.length && raw[i].isDigit() && fPos < formattedCursor) { fPos++; i++ }
+                }
+                if (i < raw.length && (raw[i] == 'E' || raw[i] == 'e') && fPos < formattedCursor) {
+                    fPos++; i++
+                    if (i < raw.length && (raw[i] == '+' || raw[i] == '-') && fPos < formattedCursor) { fPos++; i++ }
+                    while (i < raw.length && raw[i].isDigit() && fPos < formattedCursor) { fPos++; i++ }
+                }
+            }
+            c in listOf('+', '−', '×', '÷') && i > 0 -> { fPos += 3; i++ }
+            else -> { fPos++; i++ }
         }
-        rPos++
     }
-    return rPos
+    return i
 }

--- a/app/src/test/java/com/vagujhelyigergely/calculatorm3/FormattingTest.kt
+++ b/app/src/test/java/com/vagujhelyigergely/calculatorm3/FormattingTest.kt
@@ -1,0 +1,215 @@
+package com.vagujhelyigergely.calculatorm3
+
+import org.junit.Assert.assertEquals
+import org.junit.Test
+
+class FormattingTest {
+
+    // ── formatExpression ────────────────────────────────────────────
+
+    @Test
+    fun `separators added to 4+ digit integers`() {
+        assertEquals("1,234", formatExpression("1234"))
+        assertEquals("12,345", formatExpression("12345"))
+        assertEquals("123,456", formatExpression("123456"))
+        assertEquals("1,234,567", formatExpression("1234567"))
+        assertEquals("1,234,567,890", formatExpression("1234567890"))
+    }
+
+    @Test
+    fun `no separator for 3 or fewer digits`() {
+        assertEquals("0", formatExpression("0"))
+        assertEquals("1", formatExpression("1"))
+        assertEquals("12", formatExpression("12"))
+        assertEquals("123", formatExpression("123"))
+    }
+
+    @Test
+    fun `separators only in integer part of decimals`() {
+        assertEquals("1,234.56", formatExpression("1234.56"))
+        assertEquals("1,000.5", formatExpression("1000.5"))
+        assertEquals("1.23456", formatExpression("1.23456"))
+        assertEquals("0.123456", formatExpression("0.123456"))
+    }
+
+    @Test
+    fun `operator spacing preserved with separators`() {
+        assertEquals("12,345 + 67,890", formatExpression("12345+67890"))
+        assertEquals("1,000 × 2,000", formatExpression("1000×2000"))
+        assertEquals("1,000 ÷ 500", formatExpression("1000÷500"))
+        assertEquals("1,000 − 500", formatExpression("1000−500"))
+    }
+
+    @Test
+    fun `no spacing for operator at position 0`() {
+        assertEquals("+5,000", formatExpression("+5000"))
+        assertEquals("×1,234", formatExpression("×1234"))
+    }
+
+    @Test
+    fun `ascii minus from negate not spaced`() {
+        assertEquals("-12,345", formatExpression("-12345"))
+        assertEquals("5 + -1,000", formatExpression("5+-1000"))
+    }
+
+    @Test
+    fun `E notation passed through without separators`() {
+        assertEquals("1E+30", formatExpression("1E+30"))
+        assertEquals("1.23E+30", formatExpression("1.23E+30"))
+        assertEquals("369.7E+195", formatExpression("369.7E+195"))
+        assertEquals("5E-3", formatExpression("5E-3"))
+    }
+
+    @Test
+    fun `special characters pass through`() {
+        assertEquals("√(12,345)", formatExpression("√(12345)"))
+        assertEquals("π", formatExpression("π"))
+        assertEquals("12,345!", formatExpression("12345!"))
+        assertEquals("1,000%", formatExpression("1000%"))
+        assertEquals("2,000^3", formatExpression("2000^3"))
+    }
+
+    @Test
+    fun `empty and dot-start strings`() {
+        assertEquals("", formatExpression(""))
+        assertEquals(".", formatExpression("."))
+        assertEquals(".5", formatExpression(".5"))
+        assertEquals(".12345", formatExpression(".12345"))
+    }
+
+    @Test
+    fun `history strings formatted correctly`() {
+        assertEquals("1,000 + 2,000 =", formatExpression("1000+2000 ="))
+        assertEquals("12,345 =", formatExpression("12345 ="))
+    }
+
+    // ── formatResultNumber ──────────────────────────────────────────
+
+    @Test
+    fun `result separators for large numbers`() {
+        assertEquals("1,234", formatResultNumber("1234"))
+        assertEquals("12,345", formatResultNumber("12345"))
+        assertEquals("1,234,567", formatResultNumber("1234567"))
+    }
+
+    @Test
+    fun `result no separator for small numbers`() {
+        assertEquals("0", formatResultNumber("0"))
+        assertEquals("123", formatResultNumber("123"))
+        assertEquals("999", formatResultNumber("999"))
+    }
+
+    @Test
+    fun `result handles decimals`() {
+        assertEquals("1,000.5", formatResultNumber("1000.5"))
+        assertEquals("1,234.5678", formatResultNumber("1234.5678"))
+    }
+
+    @Test
+    fun `result handles negatives`() {
+        assertEquals("-1,234", formatResultNumber("-1234"))
+        assertEquals("-1,000.5", formatResultNumber("-1000.5"))
+    }
+
+    @Test
+    fun `result skips E notation`() {
+        assertEquals("1.23E+30", formatResultNumber("1.23E+30"))
+        assertEquals("1e10", formatResultNumber("1e10"))
+    }
+
+    @Test
+    fun `result skips errors and empty`() {
+        assertEquals("Error: divisionByZero", formatResultNumber("Error: divisionByZero"))
+        assertEquals("", formatResultNumber(""))
+    }
+
+    // ── Cursor mapping round-trips ──────────────────────────────────
+
+    @Test
+    fun `cursor round-trip simple number`() {
+        assertCursorRoundTrip("12345")
+    }
+
+    @Test
+    fun `cursor round-trip expression with operators`() {
+        assertCursorRoundTrip("12345+67890")
+    }
+
+    @Test
+    fun `cursor round-trip decimal number`() {
+        assertCursorRoundTrip("1234.5678")
+    }
+
+    @Test
+    fun `cursor round-trip negative number`() {
+        assertCursorRoundTrip("-12345")
+    }
+
+    @Test
+    fun `cursor round-trip small number`() {
+        assertCursorRoundTrip("123")
+    }
+
+    @Test
+    fun `cursor round-trip with special chars`() {
+        assertCursorRoundTrip("√(12345)")
+    }
+
+    @Test
+    fun `cursor round-trip complex expression`() {
+        assertCursorRoundTrip("12345+67890×100")
+    }
+
+    @Test
+    fun `cursor round-trip empty string`() {
+        assertCursorRoundTrip("")
+    }
+
+    // ── Cursor mapping specific positions ────────────────────────────
+
+    @Test
+    fun `cursor at end maps to formatted length`() {
+        // "12,345" has length 6
+        assertEquals(6, mapCursorToFormatted("12345", 5))
+    }
+
+    @Test
+    fun `cursor before separator maps correctly`() {
+        // raw "12345" → formatted "12,345"
+        // raw pos 2 (between '2' and '3') → formatted pos 2 (before ',')
+        assertEquals(2, mapCursorToFormatted("12345", 2))
+    }
+
+    @Test
+    fun `tap on separator maps to before next digit`() {
+        // formatted "12,345" pos 3 (after ',') → raw pos 2 (before '3')
+        assertEquals(2, mapCursorFromFormatted("12345", 3))
+    }
+
+    @Test
+    fun `cursor at position 0`() {
+        assertEquals(0, mapCursorToFormatted("12345", 0))
+        assertEquals(0, mapCursorFromFormatted("12345", 0))
+    }
+
+    @Test
+    fun `operator at position 0 counts as 1 char`() {
+        assertEquals(1, mapCursorToFormatted("+5000", 1))
+    }
+
+    @Test
+    fun `operator at non-zero position counts as 3 chars`() {
+        // "5" = 1 char, "+" = 3 chars (" + "), total = 4
+        assertEquals(4, mapCursorToFormatted("5+3", 2))
+    }
+
+    // ── Helper ──────────────────────────────────────────────────────
+
+    private fun assertCursorRoundTrip(raw: String) {
+        for (pos in 0..raw.length) {
+            val formatted = mapCursorToFormatted(raw, pos)
+            val back = mapCursorFromFormatted(raw, formatted)
+            assertEquals("Round-trip failed for \"$raw\" at pos=$pos", pos, back)
+        }
+    }
+}


### PR DESCRIPTION
  - Display numbers with comma thousand separators (e.g. 1,234,567) in expressions, result preview, history label, and history entries                                                                                                                                                                                                                                  
  - Rewrite formatExpression from regex to character-by-character parser that handles both operator spacing and separator insertion
  - Rewrite cursor mapping functions (mapCursorToFormatted / mapCursorFromFormatted) to account for separator characters so tap-to-position cursor remains accurate                                                                                                                                                                                                     
  - Add formatResultNumber for standalone result/preview formatting                                                                                                                                                                                                                                                                                                     
  - Add 26 unit tests covering separator placement, cursor round-trips, E notation, negatives, and edge cases                                                                                                                                                                                                                                                           
                                                                                                                                                                                                                                                                                                                                                                        
  Details                                                                                                                                                                                                                                                                                                                                                               
                                                                                                                                                                                                                                                                                                                                                                        
  - Separators are display-only — raw expressions and evaluation are unaffected                                                                                                                                                                                                                                                                                         
  - Only the integer part of numbers gets separators; decimal digits and E notation are left untouched
  - Numbers with 3 or fewer digits are unchanged  