### PR TITLE
Fix native handle use-after-free, silent capture errors, and scan len…

### DIFF
--- a/app/src/main/java/com/vagujhelyigergely/calculatorm3/CalculatorViewModel.kt
+++ b/app/src/main/java/com/vagujhelyigergely/calculatorm3/CalculatorViewModel.kt
@@ -119,8 +119,9 @@ class CalculatorViewModel(
     }
 
     fun setExpressionFromScan(expr: String) {
-        expression = expr
-        cursorPosition = expr.length
+        val clamped = expr.take(MAX_EXPRESSION_LENGTH)
+        expression = clamped
+        cursorPosition = clamped.length
         result = ""
         history = ""
         updatePreview()

--- a/app/src/main/java/com/vagujhelyigergely/calculatorm3/ai/LiteRTSolver.kt
+++ b/app/src/main/java/com/vagujhelyigergely/calculatorm3/ai/LiteRTSolver.kt
@@ -8,6 +8,8 @@ import com.google.ai.edge.litertlm.ConversationConfig
 import com.google.ai.edge.litertlm.Engine
 import com.google.ai.edge.litertlm.EngineConfig
 import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.sync.Mutex
+import kotlinx.coroutines.sync.withLock
 import kotlinx.coroutines.withContext
 
 /**
@@ -15,8 +17,9 @@ import kotlinx.coroutines.withContext
  */
 class LiteRTSolver : MathSolver {
 
-    private var engine: Engine? = null
-    private var conversation: Conversation? = null
+    private val mutex = Mutex()
+    @Volatile private var engine: Engine? = null
+    @Volatile private var conversation: Conversation? = null
 
     override val isModelLoaded: Boolean get() = engine != null && conversation != null
 
@@ -45,39 +48,43 @@ class LiteRTSolver : MathSolver {
     override suspend fun solveFromImageStreaming(
         imagePath: String,
         onToken: suspend (partialRaw: String) -> Unit
-    ): Result<RecognitionResult> = withContext(Dispatchers.IO) {
-        val conv = conversation
-            ?: return@withContext Result.failure(IllegalStateException("Model not loaded"))
-        try {
-            val rawBuilder = StringBuilder()
-            conv.sendMessageAsync(
-                Contents.of(
-                    Content.ImageFile(imagePath),
-                    Content.Text(SolverPrompts.USER_PROMPT)
-                )
-            ).collect { message ->
-                val text = message.contents.contents
-                    .filterIsInstance<Content.Text>()
-                    .joinToString("") { it.text }
-                rawBuilder.append(text)
-                onToken(rawBuilder.toString())
+    ): Result<RecognitionResult> = mutex.withLock {
+        withContext(Dispatchers.IO) {
+            val conv = conversation
+                ?: return@withContext Result.failure(IllegalStateException("Model not loaded"))
+            try {
+                val rawBuilder = StringBuilder()
+                conv.sendMessageAsync(
+                    Contents.of(
+                        Content.ImageFile(imagePath),
+                        Content.Text(SolverPrompts.USER_PROMPT)
+                    )
+                ).collect { message ->
+                    val text = message.contents.contents
+                        .filterIsInstance<Content.Text>()
+                        .joinToString("") { it.text }
+                    rawBuilder.append(text)
+                    onToken(rawBuilder.toString())
+                }
+                val raw = rawBuilder.toString()
+                val answer = SolverPrompts.extractAnswer(raw)
+                if (answer.isBlank()) {
+                    Result.failure(RecognitionException("Could not extract a numerical answer", raw))
+                } else {
+                    Result.success(RecognitionResult(raw = raw, answer = answer))
+                }
+            } catch (e: Exception) {
+                Result.failure(e)
             }
-            val raw = rawBuilder.toString()
-            val answer = SolverPrompts.extractAnswer(raw)
-            if (answer.isBlank()) {
-                Result.failure(RecognitionException("Could not extract a numerical answer", raw))
-            } else {
-                Result.success(RecognitionResult(raw = raw, answer = answer))
-            }
-        } catch (e: Exception) {
-            Result.failure(e)
         }
     }
 
-    override fun release() {
-        conversation?.close()
-        conversation = null
-        engine?.close()
-        engine = null
+    override suspend fun release() {
+        mutex.withLock {
+            conversation?.close()
+            conversation = null
+            engine?.close()
+            engine = null
+        }
     }
 }

--- a/app/src/main/java/com/vagujhelyigergely/calculatorm3/ai/MathSolver.kt
+++ b/app/src/main/java/com/vagujhelyigergely/calculatorm3/ai/MathSolver.kt
@@ -15,7 +15,7 @@ interface MathSolver {
         imagePath: String,
         onToken: suspend (partialRaw: String) -> Unit
     ): Result<RecognitionResult>
-    fun release()
+    suspend fun release()
 }
 
 /** Shared prompts used by all backends. */

--- a/app/src/main/java/com/vagujhelyigergely/calculatorm3/ai/NobodyWhoSolver.kt
+++ b/app/src/main/java/com/vagujhelyigergely/calculatorm3/ai/NobodyWhoSolver.kt
@@ -1,6 +1,8 @@
 package com.vagujhelyigergely.calculatorm3.ai
 
 import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.sync.Mutex
+import kotlinx.coroutines.sync.withLock
 import kotlinx.coroutines.withContext
 
 /**
@@ -8,8 +10,9 @@ import kotlinx.coroutines.withContext
  */
 class NobodyWhoSolver : MathSolver {
 
-    private var modelHandle: Long = 0L
-    private var chatHandle: Long = 0L
+    private val mutex = Mutex()
+    @Volatile private var modelHandle: Long = 0L
+    @Volatile private var chatHandle: Long = 0L
 
     val isNativeLibraryAvailable: Boolean get() = NobodyWhoBridge.isAvailable
     override val isModelLoaded: Boolean get() = modelHandle != 0L && chatHandle != 0L
@@ -34,45 +37,49 @@ class NobodyWhoSolver : MathSolver {
     override suspend fun solveFromImageStreaming(
         imagePath: String,
         onToken: suspend (partialRaw: String) -> Unit
-    ): Result<RecognitionResult> = withContext(Dispatchers.IO) {
-        if (!isModelLoaded) {
-            return@withContext Result.failure(IllegalStateException("Model not loaded"))
-        }
-        var streamHandle = 0L
-        try {
-            streamHandle = NobodyWhoBridge.startAskWithImage(
-                chatHandle, SolverPrompts.USER_PROMPT, imagePath
-            )
-            val rawBuilder = StringBuilder()
-            while (true) {
-                val token = NobodyWhoBridge.nextToken(streamHandle) ?: break
-                rawBuilder.append(token)
-                onToken(rawBuilder.toString())
+    ): Result<RecognitionResult> = mutex.withLock {
+        withContext(Dispatchers.IO) {
+            if (!isModelLoaded) {
+                return@withContext Result.failure(IllegalStateException("Model not loaded"))
             }
-            val raw = rawBuilder.toString()
-            val answer = SolverPrompts.extractAnswer(raw)
-            if (answer.isBlank()) {
-                Result.failure(RecognitionException("Could not extract a numerical answer", raw))
-            } else {
-                Result.success(RecognitionResult(raw = raw, answer = answer))
-            }
-        } catch (e: Exception) {
-            Result.failure(e)
-        } finally {
-            if (streamHandle != 0L) {
-                NobodyWhoBridge.freeTokenStream(streamHandle)
+            var streamHandle = 0L
+            try {
+                streamHandle = NobodyWhoBridge.startAskWithImage(
+                    chatHandle, SolverPrompts.USER_PROMPT, imagePath
+                )
+                val rawBuilder = StringBuilder()
+                while (true) {
+                    val token = NobodyWhoBridge.nextToken(streamHandle) ?: break
+                    rawBuilder.append(token)
+                    onToken(rawBuilder.toString())
+                }
+                val raw = rawBuilder.toString()
+                val answer = SolverPrompts.extractAnswer(raw)
+                if (answer.isBlank()) {
+                    Result.failure(RecognitionException("Could not extract a numerical answer", raw))
+                } else {
+                    Result.success(RecognitionResult(raw = raw, answer = answer))
+                }
+            } catch (e: Exception) {
+                Result.failure(e)
+            } finally {
+                if (streamHandle != 0L) {
+                    NobodyWhoBridge.freeTokenStream(streamHandle)
+                }
             }
         }
     }
 
-    override fun release() {
-        if (chatHandle != 0L) {
-            NobodyWhoBridge.freeChat(chatHandle)
-            chatHandle = 0L
-        }
-        if (modelHandle != 0L) {
-            NobodyWhoBridge.freeModel(modelHandle)
-            modelHandle = 0L
+    override suspend fun release() {
+        mutex.withLock {
+            if (chatHandle != 0L) {
+                NobodyWhoBridge.freeChat(chatHandle)
+                chatHandle = 0L
+            }
+            if (modelHandle != 0L) {
+                NobodyWhoBridge.freeModel(modelHandle)
+                modelHandle = 0L
+            }
         }
     }
 

--- a/app/src/main/java/com/vagujhelyigergely/calculatorm3/camera/CameraScanScreen.kt
+++ b/app/src/main/java/com/vagujhelyigergely/calculatorm3/camera/CameraScanScreen.kt
@@ -129,6 +129,7 @@ fun CameraScanScreen(
                     is ScanUiState.Capturing -> CameraContent(
                         modelName = viewModel.selectedModelName,
                         onPhotoCaptured = { path -> viewModel.onPhotoCaptured(path) },
+                        onCaptureError = { msg -> viewModel.onCaptureError(msg) },
                         onSwitchModel = { viewModel.showModelSelection() },
                         onDismiss = onDismiss
                     )
@@ -430,6 +431,7 @@ private fun ProcessingContent(partialRaw: String, startTimeMs: Long, onDismiss: 
 private fun CameraContent(
     modelName: String,
     onPhotoCaptured: (String) -> Unit,
+    onCaptureError: (String) -> Unit,
     onSwitchModel: () -> Unit,
     onDismiss: () -> Unit
 ) {
@@ -508,6 +510,7 @@ private fun CameraContent(
                         }
                         override fun onError(exception: ImageCaptureException) {
                             Log.e("CameraScan", "Capture failed", exception)
+                            onCaptureError(exception.message ?: "Photo capture failed")
                         }
                     }
                 )

--- a/app/src/main/java/com/vagujhelyigergely/calculatorm3/camera/ScanViewModel.kt
+++ b/app/src/main/java/com/vagujhelyigergely/calculatorm3/camera/ScanViewModel.kt
@@ -12,6 +12,7 @@ import com.vagujhelyigergely.calculatorm3.ai.MathSolver
 import com.vagujhelyigergely.calculatorm3.ai.ModelManager
 import com.vagujhelyigergely.calculatorm3.ai.NobodyWhoSolver
 import com.vagujhelyigergely.calculatorm3.ai.RecognitionException
+import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.Job
 import kotlinx.coroutines.launch
@@ -243,6 +244,10 @@ class ScanViewModel(
         }
     }
 
+    fun onCaptureError(message: String) {
+        uiState = ScanUiState.Error("Capture failed: $message")
+    }
+
     fun retry() {
         if (activeSolver?.isModelLoaded == true) {
             uiState = ScanUiState.Capturing
@@ -266,7 +271,13 @@ class ScanViewModel(
     }
 
     fun releaseAll() {
-        nobodyWhoSolver.release()
-        liteRTSolver.release()
+        // Launch on IO to avoid blocking the main thread — release() acquires
+        // the solver mutex which may be held by an in-flight inference whose
+        // onToken callback dispatches to Dispatchers.Main.  Blocking main here
+        // with runBlocking would deadlock.
+        CoroutineScope(Dispatchers.IO).launch {
+            nobodyWhoSolver.release()
+            liteRTSolver.release()
+        }
     }
 }


### PR DESCRIPTION
…gth bypass

- Add mutex to NobodyWhoSolver and LiteRTSolver so release() waits for any in-flight solveFromImageStreaming() to finish before freeing native handles. Prevents SIGSEGV when user navigates away during inference.
- Release on a background CoroutineScope(IO) to avoid deadlocking the main thread (onToken dispatches to Dispatchers.Main via the Looper).
- Surface ImageCapture.onError to the UI via ScanUiState.Error instead of silently logging, so users see feedback when photo capture fails.
- Clamp scanned expressions to MAX_EXPRESSION_LENGTH in setExpressionFromScan to match the guard in insertAtCursor.