### PR TITLE
Update AI Camera Icon (Fixes #45)

### DIFF
--- a/app/src/main/java/com/vagujhelyigergely/calculatorm3/CalculatorScreen.kt
+++ b/app/src/main/java/com/vagujhelyigergely/calculatorm3/CalculatorScreen.kt
@@ -40,6 +40,7 @@ import androidx.compose.ui.text.style.TextOverflow
 import android.content.res.Configuration
 import androidx.compose.ui.platform.LocalConfiguration
 import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.semantics.contentDescription
 import androidx.compose.ui.semantics.semantics
 import androidx.compose.ui.unit.dp
@@ -181,16 +182,16 @@ private fun PortraitLayout(
         ) {
             if (onShowCamera != null) {
                 IconButton(onClick = onShowCamera) {
-                    androidx.compose.foundation.layout.Box(contentAlignment = androidx.compose.ui.Alignment.Center) {
+                    Box(contentAlignment = Alignment.Center) {
                         Icon(
-                            painter = androidx.compose.ui.res.painterResource(R.drawable.ic_ai_camera),
+                            painter = painterResource(R.drawable.ic_ai_camera),
                             contentDescription = stringResource(R.string.scan_expression),
                             tint = colorScheme.onSurfaceVariant
                         )
                         Icon(
-                            painter = androidx.compose.ui.res.painterResource(R.drawable.ic_ai_camera_overlay),
+                            painter = painterResource(R.drawable.ic_ai_camera_overlay),
                             contentDescription = null,
-                            tint = androidx.compose.ui.graphics.Color.White
+                            tint = colorScheme.surface
                         )
                     }
                 }
@@ -274,16 +275,16 @@ private fun LandscapeLayout(
             ) {
                 if (onShowCamera != null) {
                     IconButton(onClick = onShowCamera) {
-                        androidx.compose.foundation.layout.Box(contentAlignment = androidx.compose.ui.Alignment.Center) {
+                        Box(contentAlignment = Alignment.Center) {
                             Icon(
-                                painter = androidx.compose.ui.res.painterResource(R.drawable.ic_ai_camera),
+                                painter = painterResource(R.drawable.ic_ai_camera),
                                 contentDescription = stringResource(R.string.scan_expression),
                                 tint = colorScheme.onSurfaceVariant
                             )
                             Icon(
-                                painter = androidx.compose.ui.res.painterResource(R.drawable.ic_ai_camera_overlay),
+                                painter = painterResource(R.drawable.ic_ai_camera_overlay),
                                 contentDescription = null,
-                                tint = androidx.compose.ui.graphics.Color.White
+                                tint = colorScheme.surface
                             )
                         }
                     }

--- a/app/src/main/java/com/vagujhelyigergely/calculatorm3/CalculatorScreen.kt
+++ b/app/src/main/java/com/vagujhelyigergely/calculatorm3/CalculatorScreen.kt
@@ -182,15 +182,15 @@ private fun PortraitLayout(
             if (onShowCamera != null) {
                 IconButton(onClick = onShowCamera) {
                     androidx.compose.foundation.layout.Box(contentAlignment = androidx.compose.ui.Alignment.Center) {
-                        androidx.compose.foundation.layout.Box(
-                            modifier = Modifier
-                                .androidx.compose.foundation.layout.size(width = 13.dp, height = 10.dp)
-                                .androidx.compose.foundation.background(androidx.compose.ui.graphics.Color.White)
-                        )
                         Icon(
                             painter = androidx.compose.ui.res.painterResource(R.drawable.ic_ai_camera),
                             contentDescription = stringResource(R.string.scan_expression),
                             tint = colorScheme.onSurfaceVariant
+                        )
+                        Icon(
+                            painter = androidx.compose.ui.res.painterResource(R.drawable.ic_ai_camera_overlay),
+                            contentDescription = null,
+                            tint = androidx.compose.ui.graphics.Color.White
                         )
                     }
                 }
@@ -275,15 +275,15 @@ private fun LandscapeLayout(
                 if (onShowCamera != null) {
                     IconButton(onClick = onShowCamera) {
                         androidx.compose.foundation.layout.Box(contentAlignment = androidx.compose.ui.Alignment.Center) {
-                            androidx.compose.foundation.layout.Box(
-                                modifier = Modifier
-                                    .androidx.compose.foundation.layout.size(width = 13.dp, height = 10.dp)
-                                    .androidx.compose.foundation.background(androidx.compose.ui.graphics.Color.White)
-                            )
                             Icon(
                                 painter = androidx.compose.ui.res.painterResource(R.drawable.ic_ai_camera),
                                 contentDescription = stringResource(R.string.scan_expression),
                                 tint = colorScheme.onSurfaceVariant
+                            )
+                            Icon(
+                                painter = androidx.compose.ui.res.painterResource(R.drawable.ic_ai_camera_overlay),
+                                contentDescription = null,
+                                tint = androidx.compose.ui.graphics.Color.White
                             )
                         }
                     }

--- a/app/src/main/java/com/vagujhelyigergely/calculatorm3/CalculatorScreen.kt
+++ b/app/src/main/java/com/vagujhelyigergely/calculatorm3/CalculatorScreen.kt
@@ -181,11 +181,18 @@ private fun PortraitLayout(
         ) {
             if (onShowCamera != null) {
                 IconButton(onClick = onShowCamera) {
-                    Icon(
-                        imageVector = Icons.Default.CameraAlt,
-                        contentDescription = stringResource(R.string.scan_expression),
-                        tint = colorScheme.onSurfaceVariant
-                    )
+                    androidx.compose.foundation.layout.Box(contentAlignment = androidx.compose.ui.Alignment.Center) {
+                        androidx.compose.foundation.layout.Box(
+                            modifier = Modifier
+                                .androidx.compose.foundation.layout.size(width = 13.dp, height = 10.dp)
+                                .androidx.compose.foundation.background(androidx.compose.ui.graphics.Color.White)
+                        )
+                        Icon(
+                            painter = androidx.compose.ui.res.painterResource(R.drawable.ic_ai_camera),
+                            contentDescription = stringResource(R.string.scan_expression),
+                            tint = colorScheme.onSurfaceVariant
+                        )
+                    }
                 }
             }
             IconButton(onClick = onShowHistory) {
@@ -267,11 +274,18 @@ private fun LandscapeLayout(
             ) {
                 if (onShowCamera != null) {
                     IconButton(onClick = onShowCamera) {
-                        Icon(
-                            imageVector = Icons.Default.CameraAlt,
-                            contentDescription = stringResource(R.string.scan_expression),
-                            tint = colorScheme.onSurfaceVariant
-                        )
+                        androidx.compose.foundation.layout.Box(contentAlignment = androidx.compose.ui.Alignment.Center) {
+                            androidx.compose.foundation.layout.Box(
+                                modifier = Modifier
+                                    .androidx.compose.foundation.layout.size(width = 13.dp, height = 10.dp)
+                                    .androidx.compose.foundation.background(androidx.compose.ui.graphics.Color.White)
+                            )
+                            Icon(
+                                painter = androidx.compose.ui.res.painterResource(R.drawable.ic_ai_camera),
+                                contentDescription = stringResource(R.string.scan_expression),
+                                tint = colorScheme.onSurfaceVariant
+                            )
+                        }
                     }
                 }
                 IconButton(onClick = onShowHistory) {

--- a/app/src/main/res/drawable/ic_ai_camera.xml
+++ b/app/src/main/res/drawable/ic_ai_camera.xml
@@ -4,31 +4,9 @@
     android:viewportWidth="24"
     android:viewportHeight="24">
 
-  <!-- Camera Body (Solid Black) -->
+  <!-- Camera Body -->
   <path
       android:fillColor="#FF000000"
       android:pathData="M9,3 L7.17,5 H4 C2.9,5 2,5.9 2,7 v12 c0,1.1 0.9,2 2,2 h16 c1.1,0 2,-0.9 2,-2 V7 c0,-1.1 -0.9,-2 -2,-2 h-3.17 L15,3 H9 z" />
-
-  <!-- Flashlight / AI Star (White, top right) -->
-  <path
-      android:fillColor="#FFFFFF"
-      android:pathData="M19,5.5 Q19,7.5 21,7.5 Q19,7.5 19,9.5 Q19,7.5 17,7.5 Q19,7.5 19,5.5 Z" />
-
-  <!-- "AI" Letters (White, perfectly centered, Bold) -->
-  <path
-      android:strokeColor="#FFFFFF"
-      android:strokeWidth="2"
-      android:strokeLineCap="round"
-      android:strokeLineJoin="round"
-      android:fillColor="#00000000"
-      android:pathData="M7.5,16 L10,10 L12.5,16 M9.25,13 H10.75 M15.5,10 V16" />
-
-  <path
-      android:fillColor="#FFFFFF"
-      android:pathData="M20.5,0 Q20.5,3 23.5,3 Q20.5,3 20.5,6 Q20.5,3 17.5,3 Q20.5,3 20.5,0 Z" />
-
-  <path
-      android:fillColor="#FFFFFF"
-      android:pathData="M22.5,5 Q22.5,6.5 24,6.5 Q22.5,6.5 22.5,8 Q22.5,6.5 21,6.5 Q22.5,6.5 22.5,5 Z" />
 
 </vector>

--- a/app/src/main/res/drawable/ic_ai_camera.xml
+++ b/app/src/main/res/drawable/ic_ai_camera.xml
@@ -9,4 +9,14 @@
       android:fillColor="#FF000000"
       android:pathData="M9,3 L7.17,5 H4 C2.9,5 2,5.9 2,7 v12 c0,1.1 0.9,2 2,2 h16 c1.1,0 2,-0.9 2,-2 V7 c0,-1.1 -0.9,-2 -2,-2 h-3.17 L15,3 H9 z" />
 
+  <!-- Outer Star 1 -->
+  <path
+      android:fillColor="#FF000000"
+      android:pathData="M20.5,0 Q20.5,3 23.5,3 Q20.5,3 20.5,6 Q20.5,3 17.5,3 Q20.5,3 20.5,0 Z" />
+
+  <!-- Outer Star 2 -->
+  <path
+      android:fillColor="#FF000000"
+      android:pathData="M22.5,5 Q22.5,6.5 24,6.5 Q22.5,6.5 22.5,8 Q22.5,6.5 21,6.5 Q22.5,6.5 22.5,5 Z" />
+
 </vector>

--- a/app/src/main/res/drawable/ic_ai_camera.xml
+++ b/app/src/main/res/drawable/ic_ai_camera.xml
@@ -1,0 +1,34 @@
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="24dp"
+    android:height="24dp"
+    android:viewportWidth="24"
+    android:viewportHeight="24">
+
+  <!-- Camera Body (Solid Black) -->
+  <path
+      android:fillColor="#FF000000"
+      android:pathData="M9,3 L7.17,5 H4 C2.9,5 2,5.9 2,7 v12 c0,1.1 0.9,2 2,2 h16 c1.1,0 2,-0.9 2,-2 V7 c0,-1.1 -0.9,-2 -2,-2 h-3.17 L15,3 H9 z" />
+
+  <!-- Flashlight / AI Star (White, top right) -->
+  <path
+      android:fillColor="#FFFFFF"
+      android:pathData="M19,5.5 Q19,7.5 21,7.5 Q19,7.5 19,9.5 Q19,7.5 17,7.5 Q19,7.5 19,5.5 Z" />
+
+  <!-- "AI" Letters (White, perfectly centered, Bold) -->
+  <path
+      android:strokeColor="#FFFFFF"
+      android:strokeWidth="2"
+      android:strokeLineCap="round"
+      android:strokeLineJoin="round"
+      android:fillColor="#00000000"
+      android:pathData="M7.5,16 L10,10 L12.5,16 M9.25,13 H10.75 M15.5,10 V16" />
+
+  <path
+      android:fillColor="#FFFFFF"
+      android:pathData="M20.5,0 Q20.5,3 23.5,3 Q20.5,3 20.5,6 Q20.5,3 17.5,3 Q20.5,3 20.5,0 Z" />
+
+  <path
+      android:fillColor="#FFFFFF"
+      android:pathData="M22.5,5 Q22.5,6.5 24,6.5 Q22.5,6.5 22.5,8 Q22.5,6.5 21,6.5 Q22.5,6.5 22.5,5 Z" />
+
+</vector>

--- a/app/src/main/res/drawable/ic_ai_camera_overlay.xml
+++ b/app/src/main/res/drawable/ic_ai_camera_overlay.xml
@@ -1,0 +1,30 @@
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="24dp"
+    android:height="24dp"
+    android:viewportWidth="24"
+    android:viewportHeight="24">
+
+  <!-- Flashlight / AI Star (White, top right) -->
+  <path
+      android:fillColor="#FFFFFF"
+      android:pathData="M19,5.5 Q19,7.5 21,7.5 Q19,7.5 19,9.5 Q19,7.5 17,7.5 Q19,7.5 19,5.5 Z" />
+
+  <!-- "AI" Letters (White, perfectly centered, Bold) -->
+  <path
+      android:strokeColor="#FFFFFF"
+      android:strokeWidth="2"
+      android:strokeLineCap="round"
+      android:strokeLineJoin="round"
+      android:fillColor="#00000000"
+      android:pathData="M7.5,16 L10,10 L12.5,16 M9.25,13 H10.75 M15.5,10 V16" />
+
+  <!-- Stars -->
+  <path
+      android:fillColor="#FFFFFF"
+      android:pathData="M20.5,0 Q20.5,3 23.5,3 Q20.5,3 20.5,6 Q20.5,3 17.5,3 Q20.5,3 20.5,0 Z" />
+
+  <path
+      android:fillColor="#FFFFFF"
+      android:pathData="M22.5,5 Q22.5,6.5 24,6.5 Q22.5,6.5 22.5,8 Q22.5,6.5 21,6.5 Q22.5,6.5 22.5,5 Z" />
+
+</vector>

--- a/app/src/main/res/drawable/ic_ai_camera_overlay.xml
+++ b/app/src/main/res/drawable/ic_ai_camera_overlay.xml
@@ -4,7 +4,7 @@
     android:viewportWidth="24"
     android:viewportHeight="24">
 
-  <!-- Flashlight / AI Star (White, top right) -->
+  <!-- Flashlight / AI Star (White, top right inner) -->
   <path
       android:fillColor="#FFFFFF"
       android:pathData="M19,5.5 Q19,7.5 21,7.5 Q19,7.5 19,9.5 Q19,7.5 17,7.5 Q19,7.5 19,5.5 Z" />
@@ -17,14 +17,5 @@
       android:strokeLineJoin="round"
       android:fillColor="#00000000"
       android:pathData="M7.5,16 L10,10 L12.5,16 M9.25,13 H10.75 M15.5,10 V16" />
-
-  <!-- Stars -->
-  <path
-      android:fillColor="#FFFFFF"
-      android:pathData="M20.5,0 Q20.5,3 23.5,3 Q20.5,3 20.5,6 Q20.5,3 17.5,3 Q20.5,3 20.5,0 Z" />
-
-  <path
-      android:fillColor="#FFFFFF"
-      android:pathData="M22.5,5 Q22.5,6.5 24,6.5 Q22.5,6.5 22.5,8 Q22.5,6.5 21,6.5 Q22.5,6.5 22.5,5 Z" />
 
 </vector>


### PR DESCRIPTION
Fixes #45. Replaced default camera icon with a custom AI camera icon featuring a white text cutout, dynamically styled using a dual-layered approach in Jetpack Compose to fully support Material 3 light/dark mode theming.