### PR TITLE
Add first-time usage warning for experimental AI camera feature

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -94,6 +94,7 @@ dependencies {
     implementation("androidx.compose.animation:animation")
     implementation("com.google.ai.edge.litertlm:litertlm-android:0.13.1")
     implementation("androidx.work:work-runtime-ktx:2.9.1")
+    implementation("androidx.datastore:datastore-preferences:1.1.1")
     // Markdown + LaTeX rendering of the model's answer (ext-latex pulls in jlatexmath).
     implementation("io.noties.markwon:core:4.6.2")
     implementation("io.noties.markwon:ext-latex:4.6.2")

--- a/app/src/main/java/com/vagujhelyigergely/calculatorm3/CalculatorScreen.kt
+++ b/app/src/main/java/com/vagujhelyigergely/calculatorm3/CalculatorScreen.kt
@@ -45,7 +45,15 @@ import androidx.compose.ui.semantics.contentDescription
 import androidx.compose.ui.semantics.semantics
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
+import androidx.compose.ui.platform.LocalContext
+import androidx.datastore.preferences.core.booleanPreferencesKey
+import androidx.datastore.preferences.core.edit
+import androidx.datastore.preferences.preferencesDataStore
+import kotlinx.coroutines.flow.map
+import kotlinx.coroutines.launch
 
+val android.content.Context.dataStore by preferencesDataStore(name = "settings")
+val HAS_SEEN_AI_WARNING = booleanPreferencesKey("has_seen_ai_warning")
 data class CalcButton(
     val label: String,
     val type: ButtonType,
@@ -114,6 +122,47 @@ fun CalculatorScreen(
     var showCamera by rememberSaveable { mutableStateOf(false) }
     val sheetState = rememberModalBottomSheetState(skipPartiallyExpanded = true)
 
+    val context = LocalContext.current
+    val scope = rememberCoroutineScope()
+    val hasSeenAiWarning by context.dataStore.data.map { it[HAS_SEEN_AI_WARNING] ?: false }.collectAsState(initial = false)
+    var showAiWarningDialog by remember { mutableStateOf(false) }
+
+    val handleShowCamera = {
+        if (hasSeenAiWarning) {
+            showCamera = true
+        } else {
+            showAiWarningDialog = true
+        }
+    }
+
+    if (showAiWarningDialog) {
+        AlertDialog(
+            onDismissRequest = { showAiWarningDialog = false },
+            title = { Text(text = stringResource(R.string.experimental_feature_title)) },
+            text = { Text(text = stringResource(R.string.experimental_feature_warning)) },
+            confirmButton = {
+                TextButton(
+                    onClick = {
+                        scope.launch {
+                            context.dataStore.edit { preferences ->
+                                preferences[HAS_SEEN_AI_WARNING] = true
+                            }
+                        }
+                        showAiWarningDialog = false
+                        showCamera = true
+                    }
+                ) {
+                    Text(stringResource(R.string.accept))
+                }
+            },
+            dismissButton = {
+                TextButton(onClick = { showAiWarningDialog = false }) {
+                    Text(stringResource(R.string.cancel))
+                }
+            }
+        )
+    }
+
     if (showHistory) {
         HistorySheet(
             sheetState = sheetState,
@@ -146,14 +195,14 @@ fun CalculatorScreen(
                 viewModel = viewModel,
                 buttons = buttons,
                 onShowHistory = { showHistory = true },
-                onShowCamera = if (scanViewModel != null) {{ showCamera = true }} else null
+                onShowCamera = if (scanViewModel != null) handleShowCamera else null
             )
         } else {
             PortraitLayout(
                 viewModel = viewModel,
                 buttons = buttons,
                 onShowHistory = { showHistory = true },
-                onShowCamera = if (scanViewModel != null) {{ showCamera = true }} else null
+                onShowCamera = if (scanViewModel != null) handleShowCamera else null
             )
         }
     }

--- a/app/src/main/java/com/vagujhelyigergely/calculatorm3/CalculatorScreen.kt
+++ b/app/src/main/java/com/vagujhelyigergely/calculatorm3/CalculatorScreen.kt
@@ -124,14 +124,18 @@ fun CalculatorScreen(
 
     val context = LocalContext.current
     val scope = rememberCoroutineScope()
-    val hasSeenAiWarning by context.dataStore.data.map { it[HAS_SEEN_AI_WARNING] ?: false }.collectAsState(initial = false)
+    val hasSeenAiWarningState = remember(context) {
+        context.dataStore.data.map { it[HAS_SEEN_AI_WARNING] ?: false }
+    }.collectAsState(initial = false)
     var showAiWarningDialog by remember { mutableStateOf(false) }
 
-    val handleShowCamera = {
-        if (hasSeenAiWarning) {
-            showCamera = true
-        } else {
-            showAiWarningDialog = true
+    val handleShowCamera = remember {
+        {
+            if (hasSeenAiWarningState.value) {
+                showCamera = true
+            } else {
+                showAiWarningDialog = true
+            }
         }
     }
 

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -80,4 +80,7 @@
     <string name="hf_token_title">HuggingFace login required</string>
     <string name="hf_token_description">%1$s requires a free HuggingFace account.\n\n1. Sign up or log in at huggingface.co\n2. Go to the model page and click \"Agree and access repository\"\n3. Go to huggingface.co/settings/tokens and create a token\n4. Paste the token below</string>
     <string name="hf_token_label">Token (hf_...)</string>
+    <string name="experimental_feature_title">Experimental Feature</string>
+    <string name="experimental_feature_warning">The AI Camera feature is experimental and might have bugs or unexpected behavior.</string>
+    <string name="accept">Accept</string>
 </resources>


### PR DESCRIPTION
Fixes #46. Implements an experimental warning dialog when the user taps the AI camera icon for the first time, using Jetpack DataStore to persist the user's acknowledgement.