### PR TITLE
Fix #47: Check RAM before launching AI models

### DIFF
--- a/app/src/main/java/com/vagujhelyigergely/calculatorm3/CalculatorScreen.kt
+++ b/app/src/main/java/com/vagujhelyigergely/calculatorm3/CalculatorScreen.kt
@@ -54,6 +54,8 @@ import kotlinx.coroutines.launch
 
 val android.content.Context.dataStore by preferencesDataStore(name = "settings")
 val HAS_SEEN_AI_WARNING = booleanPreferencesKey("has_seen_ai_warning")
+private const val MIN_RAM_REQUIRED_GB = 4
+
 data class CalcButton(
     val label: String,
     val type: ButtonType,
@@ -129,9 +131,16 @@ fun CalculatorScreen(
     }.collectAsState(initial = false)
     var showAiWarningDialog by remember { mutableStateOf(false) }
 
-    val handleShowCamera = remember {
+    val handleShowCamera = remember(scanViewModel, context) {
         {
-            if (hasSeenAiWarningState.value) {
+            val deviceRamGb = scanViewModel?.deviceRamGb ?: Int.MAX_VALUE
+            if (deviceRamGb < MIN_RAM_REQUIRED_GB) {
+                android.widget.Toast.makeText(
+                    context,
+                    "You need more RAM to use this AI feature.",
+                    android.widget.Toast.LENGTH_SHORT
+                ).show()
+            } else if (hasSeenAiWarningState.value) {
                 showCamera = true
             } else {
                 showAiWarningDialog = true

--- a/app/src/main/java/com/vagujhelyigergely/calculatorm3/CalculatorScreen.kt
+++ b/app/src/main/java/com/vagujhelyigergely/calculatorm3/CalculatorScreen.kt
@@ -137,7 +137,7 @@ fun CalculatorScreen(
             if (deviceRamGb < MIN_RAM_REQUIRED_GB) {
                 android.widget.Toast.makeText(
                     context,
-                    "You need more RAM to use this AI feature.",
+                    context.getString(R.string.ai_feature_low_ram),
                     android.widget.Toast.LENGTH_SHORT
                 ).show()
             } else if (hasSeenAiWarningState.value) {

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -68,6 +68,7 @@
     <string name="cancel">Cancel</string>
     <string name="device_too_weak_title">Not enough memory</string>
     <string name="device_too_weak_description">This feature requires at least 4 GB of RAM. Your device has %1$d GB. The AI model cannot run on this device.</string>
+    <string name="ai_feature_low_ram">You need more RAM to use this AI feature.</string>
     <string name="ai_feature_title">AI Math Solver</string>
     <string name="ai_feature_description">This feature uses a large AI model running entirely on your device to solve handwritten math from photos.\n\nPlease note:\n\n\u2022 A model download of 4\u20136 GB is required\n\u2022 We recommend using Wi-Fi for the download\n\u2022 Running the AI model uses significant battery\n\u2022 No data is sent to the cloud</string>
     <string name="ai_feature_continue">Choose a model</string>


### PR DESCRIPTION
Closes #47. Adds a constant threshold check before navigating to the AI camera view.