### PR TITLE
Consolidate AI RAM check and correct model RAM floors

### DIFF
--- a/app/src/main/java/com/vagujhelyigergely/calculatorm3/CalculatorScreen.kt
+++ b/app/src/main/java/com/vagujhelyigergely/calculatorm3/CalculatorScreen.kt
@@ -129,22 +129,33 @@ fun CalculatorScreen(
 
     val handleShowCamera: () -> Unit = remember(scanViewModel, context, scope) {
         {
-            if (scanViewModel?.canRunAnyModel == false) {
-                android.widget.Toast.makeText(
-                    context,
-                    context.getString(R.string.ai_feature_low_ram),
-                    android.widget.Toast.LENGTH_SHORT
-                ).show()
-            } else {
-                // Read the persisted flag at click time rather than from a collected
-                // State, so a fast tap right after launch can't see a stale "not seen"
-                // value before DataStore's first async read has completed.
-                scope.launch {
-                    val hasSeenWarning = context.dataStore.data.first()[HAS_SEEN_AI_WARNING] ?: false
-                    if (hasSeenWarning) {
-                        showCamera = true
-                    } else {
-                        showAiWarningDialog = true
+            when {
+                // The button isn't shown when scanViewModel is null, but guard anyway.
+                scanViewModel == null -> Unit
+                !scanViewModel.canRunAnyModel -> {
+                    android.widget.Toast.makeText(
+                        context,
+                        context.getString(R.string.ai_feature_low_ram),
+                        android.widget.Toast.LENGTH_SHORT
+                    ).show()
+                }
+                else -> {
+                    // Read the persisted flag at click time rather than from a collected
+                    // State, so a fast tap right after launch can't see a stale "not seen"
+                    // value before DataStore's first async read. Guard the disk read —
+                    // DataStore throws IOException on failure — and default to showing the
+                    // warning so a failed read can't crash the click handler.
+                    scope.launch {
+                        val hasSeenWarning = try {
+                            context.dataStore.data.first()[HAS_SEEN_AI_WARNING] ?: false
+                        } catch (e: java.io.IOException) {
+                            false
+                        }
+                        if (hasSeenWarning) {
+                            showCamera = true
+                        } else {
+                            showAiWarningDialog = true
+                        }
                     }
                 }
             }
@@ -160,8 +171,13 @@ fun CalculatorScreen(
                 TextButton(
                     onClick = {
                         scope.launch {
-                            context.dataStore.edit { preferences ->
-                                preferences[HAS_SEEN_AI_WARNING] = true
+                            // Best-effort persist; a failed write just means the warning
+                            // shows again next time rather than crashing the app.
+                            try {
+                                context.dataStore.edit { preferences ->
+                                    preferences[HAS_SEEN_AI_WARNING] = true
+                                }
+                            } catch (e: java.io.IOException) {
                             }
                         }
                         showAiWarningDialog = false

--- a/app/src/main/java/com/vagujhelyigergely/calculatorm3/CalculatorScreen.kt
+++ b/app/src/main/java/com/vagujhelyigergely/calculatorm3/CalculatorScreen.kt
@@ -49,12 +49,11 @@ import androidx.compose.ui.platform.LocalContext
 import androidx.datastore.preferences.core.booleanPreferencesKey
 import androidx.datastore.preferences.core.edit
 import androidx.datastore.preferences.preferencesDataStore
-import kotlinx.coroutines.flow.map
+import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.launch
 
-val android.content.Context.dataStore by preferencesDataStore(name = "settings")
-val HAS_SEEN_AI_WARNING = booleanPreferencesKey("has_seen_ai_warning")
-private const val MIN_RAM_REQUIRED_GB = 4
+private val android.content.Context.dataStore by preferencesDataStore(name = "settings")
+private val HAS_SEEN_AI_WARNING = booleanPreferencesKey("has_seen_ai_warning")
 
 data class CalcButton(
     val label: String,
@@ -126,24 +125,28 @@ fun CalculatorScreen(
 
     val context = LocalContext.current
     val scope = rememberCoroutineScope()
-    val hasSeenAiWarningState = remember(context) {
-        context.dataStore.data.map { it[HAS_SEEN_AI_WARNING] ?: false }
-    }.collectAsState(initial = false)
     var showAiWarningDialog by remember { mutableStateOf(false) }
 
-    val handleShowCamera = remember(scanViewModel, context) {
+    val handleShowCamera: () -> Unit = remember(scanViewModel, context, scope) {
         {
-            val deviceRamGb = scanViewModel?.deviceRamGb ?: Int.MAX_VALUE
-            if (deviceRamGb < MIN_RAM_REQUIRED_GB) {
+            if (scanViewModel?.canRunAnyModel == false) {
                 android.widget.Toast.makeText(
                     context,
                     context.getString(R.string.ai_feature_low_ram),
                     android.widget.Toast.LENGTH_SHORT
                 ).show()
-            } else if (hasSeenAiWarningState.value) {
-                showCamera = true
             } else {
-                showAiWarningDialog = true
+                // Read the persisted flag at click time rather than from a collected
+                // State, so a fast tap right after launch can't see a stale "not seen"
+                // value before DataStore's first async read has completed.
+                scope.launch {
+                    val hasSeenWarning = context.dataStore.data.first()[HAS_SEEN_AI_WARNING] ?: false
+                    if (hasSeenWarning) {
+                        showCamera = true
+                    } else {
+                        showAiWarningDialog = true
+                    }
+                }
             }
         }
     }

--- a/app/src/main/java/com/vagujhelyigergely/calculatorm3/ai/LiteRTSolver.kt
+++ b/app/src/main/java/com/vagujhelyigergely/calculatorm3/ai/LiteRTSolver.kt
@@ -66,6 +66,11 @@ class LiteRTSolver : MathSolver {
                 modelPath = modelPath,
                 backend = backend,
                 visionBackend = visionBackend,
+                // We send exactly one image per turn (see runInference), so cap image
+                // buffers at 1 rather than the engine default. maxNumTokens (the KV-cache
+                // cap) is intentionally left at the default until we have real on-device
+                // peak-memory numbers to size it from — see MemoryProbe in ScanViewModel.
+                maxNumImages = 1,
             )
         )
         try {

--- a/app/src/main/java/com/vagujhelyigergely/calculatorm3/ai/LiteRTSolver.kt
+++ b/app/src/main/java/com/vagujhelyigergely/calculatorm3/ai/LiteRTSolver.kt
@@ -68,8 +68,8 @@ class LiteRTSolver : MathSolver {
                 visionBackend = visionBackend,
                 // We send exactly one image per turn (see runInference), so cap image
                 // buffers at 1 rather than the engine default. maxNumTokens (the KV-cache
-                // cap) is intentionally left at the default until we have real on-device
-                // peak-memory numbers to size it from — see MemoryProbe in ScanViewModel.
+                // cap) is left at default: on-device measurement showed the model weights,
+                // not the KV cache, dominate memory — so capping it wouldn't move the needle.
                 maxNumImages = 1,
             )
         )

--- a/app/src/main/java/com/vagujhelyigergely/calculatorm3/ai/ModelManager.kt
+++ b/app/src/main/java/com/vagujhelyigergely/calculatorm3/ai/ModelManager.kt
@@ -11,6 +11,7 @@ import androidx.work.OneTimeWorkRequestBuilder
 import androidx.work.WorkInfo
 import androidx.work.WorkManager
 import androidx.work.workDataOf
+import kotlin.math.ceil
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.ensureActive
 import kotlinx.coroutines.flow.Flow
@@ -47,6 +48,12 @@ enum class AiModel(
     val displayName: String,
     val description: String,
     val totalSizeDisplay: String,
+    /**
+     * Minimum *total* device RAM (marketed GB) to run this model — well above the raw
+     * weight size. Sized for our multimodal (vision) use: the on-device weight footprint
+     * plus headroom for the vision encoder, image-token KV cache, runtime, and the ~2 GB
+     * the OS and other apps hold that can't be reclaimed. E2B-class → 6 GB, E4B-class → 8 GB.
+     */
     val minRamGb: Int,
     val primaryFilename: String,
     val files: List<ModelFile>,
@@ -75,7 +82,7 @@ enum class AiModel(
         displayName = "Gemma 3n E2B",
         description = "Fast, edge optimized",
         totalSizeDisplay = "~3.7 GB",
-        minRamGb = 4,
+        minRamGb = 6,
         primaryFilename = "gemma-3n-E2B-it-int4.litertlm",
         files = listOf(
             ModelFile(
@@ -109,7 +116,7 @@ enum class AiModel(
         displayName = "Gemma 3n E4B",
         description = "Better quality, edge optimized",
         totalSizeDisplay = "~4.9 GB",
-        minRamGb = 6,
+        minRamGb = 8,
         primaryFilename = "gemma-3n-E4B-it-int4.litertlm",
         files = listOf(
             ModelFile(
@@ -160,12 +167,18 @@ class ModelManager(private val context: Context) {
     fun downloadedModels(): List<AiModel> =
         AiModel.entries.filter { areModelsAvailable(it) }
 
+    /**
+     * Marketed device RAM in GB. [ActivityManager.MemoryInfo.totalMem] reports the RAM
+     * the kernel sees, which is ~0.3–0.9 GB below the marketed size (GPU/modem/kernel
+     * carveouts). Round up so a "6 GB"/"8 GB" device reporting e.g. 5.6/7.4 GiB maps back
+     * to 6/8 instead of being undercounted and wrongly rejected by [canRunAnyModel].
+     */
     val deviceRamGb: Int
         get() {
             val activityManager = context.getSystemService(Context.ACTIVITY_SERVICE) as ActivityManager
             val memInfo = ActivityManager.MemoryInfo()
             activityManager.getMemoryInfo(memInfo)
-            return (memInfo.totalMem / (1024L * 1024L * 1024L)).toInt()
+            return ceil(memInfo.totalMem / (1024.0 * 1024.0 * 1024.0)).toInt()
         }
 
     fun isModelTooLarge(model: AiModel): Boolean = model.minRamGb > deviceRamGb

--- a/app/src/main/java/com/vagujhelyigergely/calculatorm3/camera/CameraScanScreen.kt
+++ b/app/src/main/java/com/vagujhelyigergely/calculatorm3/camera/CameraScanScreen.kt
@@ -884,7 +884,11 @@ private fun ModelCard(
 ) {
     Surface(
         onClick = {
-            if (isDownloaded) onSelectModel(model) else onDownloadModel(model)
+            when {
+                isDownloaded -> onSelectModel(model)
+                tooLarge -> Unit  // can't run on this device — the card shows why
+                else -> onDownloadModel(model)
+            }
         },
         modifier = Modifier
             .fillMaxWidth()

--- a/app/src/main/java/com/vagujhelyigergely/calculatorm3/camera/CameraScanScreen.kt
+++ b/app/src/main/java/com/vagujhelyigergely/calculatorm3/camera/CameraScanScreen.kt
@@ -154,13 +154,6 @@ fun CameraScanScreen(
                         onRetry = { viewModel.retry() },
                         onDismiss = onDismiss
                     )
-                    is ScanUiState.DeviceTooWeak -> StatusContent(
-                        icon = Icons.Default.ErrorOutline,
-                        title = stringResource(R.string.device_too_weak_title),
-                        subtitle = stringResource(R.string.device_too_weak_description, viewModel.deviceRamGb),
-                        showProgress = false,
-                        onDismiss = onDismiss
-                    )
                     is ScanUiState.FirstTimeWarning -> FirstTimeWarningContent(
                         onContinue = { viewModel.showModelSelection() },
                         onDismiss = onDismiss

--- a/app/src/main/java/com/vagujhelyigergely/calculatorm3/camera/ScanViewModel.kt
+++ b/app/src/main/java/com/vagujhelyigergely/calculatorm3/camera/ScanViewModel.kt
@@ -51,7 +51,6 @@ sealed interface ScanUiState {
     data class TokenRequired(val model: AiModel) : ScanUiState
     data class AuthError(val httpCode: Int, val model: AiModel) : ScanUiState
     data object FirstTimeWarning : ScanUiState
-    data object DeviceTooWeak : ScanUiState
     data class MobileDataWarning(val model: AiModel) : ScanUiState
 }
 
@@ -67,10 +66,6 @@ class ScanViewModel(
     private var downloadObserver: Job? = null
 
     fun initialize() {
-        if (!modelManager.canRunAnyModel) {
-            uiState = ScanUiState.DeviceTooWeak
-            return
-        }
         viewModelScope.launch {
             // Re-attach to a download already running in the background (e.g. started
             // before the app was backgrounded) instead of showing the idle UI.
@@ -372,7 +367,9 @@ class ScanViewModel(
     }
 
     val selectedModelName: String get() = modelManager.selectedModel.displayName
-    val deviceRamGb: Int get() = modelManager.deviceRamGb
+
+    /** True if the device has enough RAM to run at least one AI model. */
+    val canRunAnyModel: Boolean get() = modelManager.canRunAnyModel
 
     override fun onCleared() {
         super.onCleared()

--- a/app/src/main/java/com/vagujhelyigergely/calculatorm3/camera/ScanViewModel.kt
+++ b/app/src/main/java/com/vagujhelyigergely/calculatorm3/camera/ScanViewModel.kt
@@ -138,6 +138,9 @@ class ScanViewModel(
     }
 
     fun startDownload(model: AiModel) {
+        // Never fetch a model the device can't run (the picker also blocks this, but
+        // guard here so no path can download an unusable multi-GB model).
+        if (modelManager.isModelTooLarge(model)) return
         modelManager.selectedModel = model
         if (model.requiresAuth && !hasHfToken) {
             uiState = ScanUiState.TokenRequired(model)

--- a/app/src/main/java/com/vagujhelyigergely/calculatorm3/camera/ScanViewModel.kt
+++ b/app/src/main/java/com/vagujhelyigergely/calculatorm3/camera/ScanViewModel.kt
@@ -16,8 +16,6 @@ import com.vagujhelyigergely.calculatorm3.ai.RecognitionException
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.Job
-import kotlinx.coroutines.delay
-import kotlinx.coroutines.isActive
 import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.withContext
@@ -231,60 +229,53 @@ class ScanViewModel(
     fun onPhotoCaptured(imagePath: String) {
         val model = modelManager.selectedModel
         viewModelScope.launch {
-            // TEMP: probe peak memory across model load + inference so thresholds can be
-            // set from real numbers rather than estimates (see [MemoryProbe]).
-            val memProbe = MemoryProbe().also { it.start(this) }
+            // Load the model now that a photo exists (it wasn't resident while the
+            // camera app was open). Shows "Loading AI model…" then proceeds.
+            if (!ensureModelLoaded(model)) {
+                try { java.io.File(imagePath).delete() } catch (_: Exception) {}
+                return@launch
+            }
+            val startTime = System.currentTimeMillis()
+            val backend = solver.activeBackend + (solver.lastGpuError?.let { "  ⚠ GPU: $it" } ?: "")
+            uiState = ScanUiState.Processing(startTimeMs = startTime, backend = backend)
+            // Apply EXIF rotation + downscale: a full-res photo can blow up the
+            // vision pipeline's memory, and the camera stores it sideways with an
+            // EXIF orientation tag the model would otherwise ignore.
+            val processPath = withContext(Dispatchers.IO) {
+                prepareImage(imagePath, MAX_IMAGE_EDGE) ?: imagePath
+            }
             try {
-                // Load the model now that a photo exists (it wasn't resident while the
-                // camera app was open). Shows "Loading AI model…" then proceeds.
-                if (!ensureModelLoaded(model)) {
-                    try { java.io.File(imagePath).delete() } catch (_: Exception) {}
-                    return@launch
-                }
-                val startTime = System.currentTimeMillis()
-                val backend = solver.activeBackend + (solver.lastGpuError?.let { "  ⚠ GPU: $it" } ?: "")
-                uiState = ScanUiState.Processing(startTimeMs = startTime, backend = backend)
-                // Apply EXIF rotation + downscale: a full-res photo can blow up the
-                // vision pipeline's memory, and the camera stores it sideways with an
-                // EXIF orientation tag the model would otherwise ignore.
-                val processPath = withContext(Dispatchers.IO) {
-                    prepareImage(imagePath, MAX_IMAGE_EDGE) ?: imagePath
-                }
-                try {
-                    var tokenCount = 0
-                    val result = solver.solveFromImageStreaming(processPath) { partialRaw ->
-                        tokenCount++
-                        withContext(Dispatchers.Main) {
-                            uiState = ScanUiState.Processing(
-                                partialRaw = partialRaw,
-                                startTimeMs = startTime,
-                                tokenCount = tokenCount,
-                                backend = backend
-                            )
-                        }
-                    }
-                    val elapsed = System.currentTimeMillis() - startTime
-                    uiState = result.fold(
-                        onSuccess = { ScanUiState.Success(it.answer, it.raw, elapsed, tokenCount, backend) },
-                        onFailure = {
-                            val raw = (it as? RecognitionException)?.rawResponse
-                            ScanUiState.Error(it.message ?: "Recognition failed", raw)
-                        }
-                    )
-                } catch (e: Throwable) {
-                    // Let cancellation (e.g. user closed the screen) propagate instead
-                    // of showing it as an inference error.
-                    if (e is kotlinx.coroutines.CancellationException) throw e
-                    uiState = ScanUiState.Error("Inference failed: ${e.message}")
-                } finally {
-                    // Clean up captured photos
-                    try { java.io.File(imagePath).delete() } catch (_: Exception) {}
-                    if (processPath != imagePath) {
-                        try { java.io.File(processPath).delete() } catch (_: Exception) {}
+                var tokenCount = 0
+                val result = solver.solveFromImageStreaming(processPath) { partialRaw ->
+                    tokenCount++
+                    withContext(Dispatchers.Main) {
+                        uiState = ScanUiState.Processing(
+                            partialRaw = partialRaw,
+                            startTimeMs = startTime,
+                            tokenCount = tokenCount,
+                            backend = backend
+                        )
                     }
                 }
+                val elapsed = System.currentTimeMillis() - startTime
+                uiState = result.fold(
+                    onSuccess = { ScanUiState.Success(it.answer, it.raw, elapsed, tokenCount, backend) },
+                    onFailure = {
+                        val raw = (it as? RecognitionException)?.rawResponse
+                        ScanUiState.Error(it.message ?: "Recognition failed", raw)
+                    }
+                )
+            } catch (e: Throwable) {
+                // Let cancellation (e.g. user closed the screen) propagate instead
+                // of showing it as an inference error.
+                if (e is kotlinx.coroutines.CancellationException) throw e
+                uiState = ScanUiState.Error("Inference failed: ${e.message}")
             } finally {
-                memProbe.stopAndLog("${model.id} [${solver.activeBackend}]")
+                // Clean up captured photos
+                try { java.io.File(imagePath).delete() } catch (_: Exception) {}
+                if (processPath != imagePath) {
+                    try { java.io.File(processPath).delete() } catch (_: Exception) {}
+                }
             }
         }
     }
@@ -394,44 +385,6 @@ class ScanViewModel(
         // with runBlocking would deadlock.
         CoroutineScope(Dispatchers.IO).launch {
             solver.release()
-        }
-    }
-
-    /**
-     * TEMP instrumentation: polls process memory on a background coroutine while a scan
-     * runs and logs the peak (total PSS / native / graphics), so [com.vagujhelyigergely.calculatorm3.ai.AiModel.minRamGb]
-     * and a future EngineConfig.maxNumTokens cap can be set from real per-model numbers
-     * instead of estimates. Read with `adb logcat -s MemoryProbe`. Remove once validated.
-     */
-    private class MemoryProbe {
-        private var job: Job? = null
-        @Volatile private var peakTotalKb = 0L
-        @Volatile private var peakNativeKb = 0L
-        @Volatile private var peakGraphicsKb = 0L
-
-        fun start(scope: CoroutineScope) {
-            val info = android.os.Debug.MemoryInfo()
-            job = scope.launch(Dispatchers.Default) {
-                while (isActive) {
-                    android.os.Debug.getMemoryInfo(info)
-                    peakTotalKb = maxOf(peakTotalKb, info.totalPss.toLong())
-                    peakNativeKb = maxOf(peakNativeKb, info.nativePss.toLong())
-                    peakGraphicsKb = maxOf(
-                        peakGraphicsKb,
-                        info.getMemoryStat("summary.graphics")?.toLongOrNull() ?: 0L
-                    )
-                    delay(250)
-                }
-            }
-        }
-
-        fun stopAndLog(label: String) {
-            job?.cancel()
-            job = null
-            android.util.Log.i(
-                "MemoryProbe",
-                "$label  peak total=${peakTotalKb / 1024}MB native=${peakNativeKb / 1024}MB graphics=${peakGraphicsKb / 1024}MB"
-            )
         }
     }
 

--- a/app/src/main/java/com/vagujhelyigergely/calculatorm3/camera/ScanViewModel.kt
+++ b/app/src/main/java/com/vagujhelyigergely/calculatorm3/camera/ScanViewModel.kt
@@ -16,6 +16,8 @@ import com.vagujhelyigergely.calculatorm3.ai.RecognitionException
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.Job
+import kotlinx.coroutines.delay
+import kotlinx.coroutines.isActive
 import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.withContext
@@ -229,53 +231,60 @@ class ScanViewModel(
     fun onPhotoCaptured(imagePath: String) {
         val model = modelManager.selectedModel
         viewModelScope.launch {
-            // Load the model now that a photo exists (it wasn't resident while the
-            // camera app was open). Shows "Loading AI model…" then proceeds.
-            if (!ensureModelLoaded(model)) {
-                try { java.io.File(imagePath).delete() } catch (_: Exception) {}
-                return@launch
-            }
-            val startTime = System.currentTimeMillis()
-            val backend = solver.activeBackend + (solver.lastGpuError?.let { "  ⚠ GPU: $it" } ?: "")
-            uiState = ScanUiState.Processing(startTimeMs = startTime, backend = backend)
-            // Apply EXIF rotation + downscale: a full-res photo can blow up the
-            // vision pipeline's memory, and the camera stores it sideways with an
-            // EXIF orientation tag the model would otherwise ignore.
-            val processPath = withContext(Dispatchers.IO) {
-                prepareImage(imagePath, MAX_IMAGE_EDGE) ?: imagePath
-            }
+            // TEMP: probe peak memory across model load + inference so thresholds can be
+            // set from real numbers rather than estimates (see [MemoryProbe]).
+            val memProbe = MemoryProbe().also { it.start(this) }
             try {
-                var tokenCount = 0
-                val result = solver.solveFromImageStreaming(processPath) { partialRaw ->
-                    tokenCount++
-                    withContext(Dispatchers.Main) {
-                        uiState = ScanUiState.Processing(
-                            partialRaw = partialRaw,
-                            startTimeMs = startTime,
-                            tokenCount = tokenCount,
-                            backend = backend
-                        )
+                // Load the model now that a photo exists (it wasn't resident while the
+                // camera app was open). Shows "Loading AI model…" then proceeds.
+                if (!ensureModelLoaded(model)) {
+                    try { java.io.File(imagePath).delete() } catch (_: Exception) {}
+                    return@launch
+                }
+                val startTime = System.currentTimeMillis()
+                val backend = solver.activeBackend + (solver.lastGpuError?.let { "  ⚠ GPU: $it" } ?: "")
+                uiState = ScanUiState.Processing(startTimeMs = startTime, backend = backend)
+                // Apply EXIF rotation + downscale: a full-res photo can blow up the
+                // vision pipeline's memory, and the camera stores it sideways with an
+                // EXIF orientation tag the model would otherwise ignore.
+                val processPath = withContext(Dispatchers.IO) {
+                    prepareImage(imagePath, MAX_IMAGE_EDGE) ?: imagePath
+                }
+                try {
+                    var tokenCount = 0
+                    val result = solver.solveFromImageStreaming(processPath) { partialRaw ->
+                        tokenCount++
+                        withContext(Dispatchers.Main) {
+                            uiState = ScanUiState.Processing(
+                                partialRaw = partialRaw,
+                                startTimeMs = startTime,
+                                tokenCount = tokenCount,
+                                backend = backend
+                            )
+                        }
+                    }
+                    val elapsed = System.currentTimeMillis() - startTime
+                    uiState = result.fold(
+                        onSuccess = { ScanUiState.Success(it.answer, it.raw, elapsed, tokenCount, backend) },
+                        onFailure = {
+                            val raw = (it as? RecognitionException)?.rawResponse
+                            ScanUiState.Error(it.message ?: "Recognition failed", raw)
+                        }
+                    )
+                } catch (e: Throwable) {
+                    // Let cancellation (e.g. user closed the screen) propagate instead
+                    // of showing it as an inference error.
+                    if (e is kotlinx.coroutines.CancellationException) throw e
+                    uiState = ScanUiState.Error("Inference failed: ${e.message}")
+                } finally {
+                    // Clean up captured photos
+                    try { java.io.File(imagePath).delete() } catch (_: Exception) {}
+                    if (processPath != imagePath) {
+                        try { java.io.File(processPath).delete() } catch (_: Exception) {}
                     }
                 }
-                val elapsed = System.currentTimeMillis() - startTime
-                uiState = result.fold(
-                    onSuccess = { ScanUiState.Success(it.answer, it.raw, elapsed, tokenCount, backend) },
-                    onFailure = {
-                        val raw = (it as? RecognitionException)?.rawResponse
-                        ScanUiState.Error(it.message ?: "Recognition failed", raw)
-                    }
-                )
-            } catch (e: Throwable) {
-                // Let cancellation (e.g. user closed the screen) propagate instead
-                // of showing it as an inference error.
-                if (e is kotlinx.coroutines.CancellationException) throw e
-                uiState = ScanUiState.Error("Inference failed: ${e.message}")
             } finally {
-                // Clean up captured photos
-                try { java.io.File(imagePath).delete() } catch (_: Exception) {}
-                if (processPath != imagePath) {
-                    try { java.io.File(processPath).delete() } catch (_: Exception) {}
-                }
+                memProbe.stopAndLog("${model.id} [${solver.activeBackend}]")
             }
         }
     }
@@ -385,6 +394,44 @@ class ScanViewModel(
         // with runBlocking would deadlock.
         CoroutineScope(Dispatchers.IO).launch {
             solver.release()
+        }
+    }
+
+    /**
+     * TEMP instrumentation: polls process memory on a background coroutine while a scan
+     * runs and logs the peak (total PSS / native / graphics), so [com.vagujhelyigergely.calculatorm3.ai.AiModel.minRamGb]
+     * and a future EngineConfig.maxNumTokens cap can be set from real per-model numbers
+     * instead of estimates. Read with `adb logcat -s MemoryProbe`. Remove once validated.
+     */
+    private class MemoryProbe {
+        private var job: Job? = null
+        @Volatile private var peakTotalKb = 0L
+        @Volatile private var peakNativeKb = 0L
+        @Volatile private var peakGraphicsKb = 0L
+
+        fun start(scope: CoroutineScope) {
+            val info = android.os.Debug.MemoryInfo()
+            job = scope.launch(Dispatchers.Default) {
+                while (isActive) {
+                    android.os.Debug.getMemoryInfo(info)
+                    peakTotalKb = maxOf(peakTotalKb, info.totalPss.toLong())
+                    peakNativeKb = maxOf(peakNativeKb, info.nativePss.toLong())
+                    peakGraphicsKb = maxOf(
+                        peakGraphicsKb,
+                        info.getMemoryStat("summary.graphics")?.toLongOrNull() ?: 0L
+                    )
+                    delay(250)
+                }
+            }
+        }
+
+        fun stopAndLog(label: String) {
+            job?.cancel()
+            job = null
+            android.util.Log.i(
+                "MemoryProbe",
+                "$label  peak total=${peakTotalKb / 1024}MB native=${peakNativeKb / 1024}MB graphics=${peakGraphicsKb / 1024}MB"
+            )
         }
     }
 

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -66,8 +66,6 @@
     <string name="mobile_data_description">You are about to download %1$s using mobile data. This may incur charges from your carrier.</string>
     <string name="download_anyway">Download anyway</string>
     <string name="cancel">Cancel</string>
-    <string name="device_too_weak_title">Not enough memory</string>
-    <string name="device_too_weak_description">This feature requires at least 4 GB of RAM. Your device has %1$d GB. The AI model cannot run on this device.</string>
     <string name="ai_feature_low_ram">You need more RAM to use this AI feature.</string>
     <string name="ai_feature_title">AI Math Solver</string>
     <string name="ai_feature_description">This feature uses a large AI model running entirely on your device to solve handwritten math from photos.\n\nPlease note:\n\n\u2022 A model download of 4\u20136 GB is required\n\u2022 We recommend using Wi-Fi for the download\n\u2022 Running the AI model uses significant battery\n\u2022 No data is sent to the cloud</string>


### PR DESCRIPTION
Follow-ups to the device RAM check from #47, tightening how the on-device AI math-solver gates on memory.

## Changes
- **Single RAM gate.** Route the pre-launch camera gate through `ScanViewModel.canRunAnyModel` instead of a hardcoded 4 GB constant, so it tracks the models' actual `minRamGb`. Removes the now-unreachable in-camera `DeviceTooWeak` state and its strings, and keeps the exact `ai_feature_low_ram` Toast #47 specified.
- **One-time warning race.** Read the "seen experimental warning" flag from DataStore at click time instead of via `collectAsState(initial = false)`, so a fast tap right after launch can't re-show the one-time dialog.
- **Correct `minRamGb` floors.** Set per-model floors from Google's published on-device *multimodal* footprints: E2B-class → 6 GB, E4B-class → 8 GB (raises Gemma 3n E2B 4→6 and Gemma 3n E4B 6→8; the old values were partly inverted).
- **Round device RAM up.** `deviceRamGb` rounds `totalMem` to the nearest GB instead of truncating — a real 6/8 GB device reports ~5.6/7.4 GiB, which `floor()` read as 5/7 and wrongly rejected.
- **Cap image buffers.** `EngineConfig.maxNumImages = 1` (exactly one photo is sent per turn).

## Validation
Floors confirmed on real hardware via system-wide available-RAM measurement (per-app PSS undercounts memory-mapped weights):
- **Galaxy Note 9 (6 GB):** runs the E2B models (~2.6–3.0 GiB working set) — tight but works. The `ceil` fix is what admits it (it reports 5.49 GiB → would be rejected as `5` otherwise).
- **Galaxy S25 (12 GB):** Gemma 4 E4B ~4.8 GiB, Gemma 3n E4B ~3.7 GiB working set.

`compileDebugKotlin` passes.
