### PR TITLE
Polish AI views with Material 3 design (#49)

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -72,6 +72,15 @@ android {
     buildFeatures {
         compose = true
     }
+    lint {
+        // The bumped AndroidX libraries (Compose 1.9 / lifecycle) ship lint checks built
+        // against a newer lint-api than AGP 8.7.3 bundles, so the built-in
+        // NonNullableMutableLiveDataDetector throws IncompatibleClassChangeError mid-analysis
+        // and aborts the release-only lintVital task. It's a tooling-version crash, not a code
+        // finding; disabling its issue id makes lint skip that one detector (its UAST visitor
+        // never runs) while every other lint check keeps working.
+        disable += "NullSafeMutableLiveData"
+    }
     dependenciesInfo {
         includeInApk = false
         includeInBundle = false
@@ -88,14 +97,18 @@ android {
 }
 
 dependencies {
-    implementation(platform("androidx.compose:compose-bom:2024.12.01"))
+    implementation(platform("androidx.compose:compose-bom:2025.10.01"))
     implementation("androidx.core:core-ktx:1.15.0")
     implementation("androidx.lifecycle:lifecycle-runtime-ktx:2.8.7")
     implementation("androidx.activity:activity-compose:1.9.3")
     implementation("androidx.compose.ui:ui")
     implementation("androidx.compose.ui:ui-graphics")
     implementation("androidx.compose.ui:ui-tooling-preview")
-    implementation("androidx.compose.material3:material3:1.3.1")
+    // material3 1.5.0-alpha brings the M3-Expressive loaders (LoadingIndicator,
+    // LinearWavyProgressIndicator) used by the AI views — they are NOT in 1.4.0 stable.
+    // alpha14 is the last 1.5.0 alpha that still targets Compose 1.8/1.9 (the BOM above);
+    // alpha16+ requires Compose 1.11+. Pinned explicitly to override the BOM's material3.
+    implementation("androidx.compose.material3:material3:1.5.0-alpha14")
     implementation("androidx.compose.material:material-icons-extended")
     implementation("androidx.compose.animation:animation")
     implementation("com.google.ai.edge.litertlm:litertlm-android:0.13.1")
@@ -112,7 +125,7 @@ dependencies {
 
     testImplementation("junit:junit:4.13.2")
 
-    androidTestImplementation(platform("androidx.compose:compose-bom:2024.12.01"))
+    androidTestImplementation(platform("androidx.compose:compose-bom:2025.10.01"))
     androidTestImplementation("androidx.compose.ui:ui-test-junit4")
     androidTestImplementation("androidx.test.ext:junit:1.2.1")
     androidTestImplementation("androidx.test:runner:1.6.2")

--- a/app/src/debug/java/com/vagujhelyigergely/calculatorm3/camera/ScanPreviews.kt
+++ b/app/src/debug/java/com/vagujhelyigergely/calculatorm3/camera/ScanPreviews.kt
@@ -1,0 +1,154 @@
+package com.vagujhelyigergely.calculatorm3.camera
+
+import android.content.res.Configuration.UI_MODE_NIGHT_YES
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.padding
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.CheckCircle
+import androidx.compose.material.icons.filled.CloudDownload
+import androidx.compose.material.icons.filled.ErrorOutline
+import androidx.compose.material.icons.filled.Psychology
+import androidx.compose.material3.CardDefaults
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Surface
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.unit.dp
+import com.vagujhelyigergely.calculatorm3.ui.theme.CalculatorM3Theme
+
+// Debug-only previews so the redesigned AI surfaces can be eyeballed in Android Studio
+// without running on-device inference. They exercise the reusable building blocks from
+// ScanComponents.kt; the shared-element modifiers no-op outside a SharedTransitionLayout,
+// so each block renders standalone.
+
+@Preview(name = "Loading", showBackground = true)
+@Preview(name = "Loading · dark", showBackground = true, uiMode = UI_MODE_NIGHT_YES)
+@Composable
+private fun LoadingPreview() {
+    CalculatorM3Theme {
+        Surface {
+            Box(Modifier.fillMaxSize()) {
+                AiHero(
+                    title = "Loading AI model…",
+                    subtitle = "Loading the vision model into memory. This may take up to a minute on first use.",
+                    loading = true,
+                    modifier = Modifier.align(Alignment.Center).padding(32.dp)
+                )
+            }
+        }
+    }
+}
+
+@Preview(name = "Processing", showBackground = true)
+@Composable
+private fun ProcessingPreview() {
+    CalculatorM3Theme {
+        Surface {
+            Column(
+                Modifier.fillMaxSize().padding(32.dp),
+                horizontalAlignment = Alignment.CenterHorizontally,
+                verticalArrangement = Arrangement.spacedBy(20.dp)
+            ) {
+                AiHero(title = "Solving…", icon = Icons.Default.Psychology, pulsing = true)
+                AiCard(Modifier.fillMaxWidth()) {
+                    Text(
+                        "To solve 3x + 6 = 21, subtract 6: 3x = 15, then divide by 3 → x = 5.",
+                        style = MaterialTheme.typography.bodyMedium,
+                        modifier = Modifier.padding(16.dp)
+                    )
+                }
+            }
+        }
+    }
+}
+
+@Preview(name = "Success", showBackground = true)
+@Preview(name = "Success · dark", showBackground = true, uiMode = UI_MODE_NIGHT_YES)
+@Composable
+private fun SuccessPreview() {
+    CalculatorM3Theme {
+        Surface {
+            Column(
+                Modifier.fillMaxSize().padding(32.dp),
+                horizontalAlignment = Alignment.CenterHorizontally,
+                verticalArrangement = Arrangement.spacedBy(20.dp)
+            ) {
+                AiHero(title = "Answer found", icon = Icons.Default.CheckCircle)
+                AiCard(Modifier.fillMaxWidth()) {
+                    Text(
+                        "x = 5",
+                        style = MaterialTheme.typography.headlineSmall,
+                        modifier = Modifier.padding(16.dp)
+                    )
+                }
+            }
+        }
+    }
+}
+
+@Preview(name = "Error", showBackground = true)
+@Composable
+private fun ErrorPreview() {
+    CalculatorM3Theme {
+        Surface {
+            Column(
+                Modifier.fillMaxSize().padding(32.dp),
+                horizontalAlignment = Alignment.CenterHorizontally,
+                verticalArrangement = Arrangement.spacedBy(16.dp)
+            ) {
+                AiHero(
+                    title = "Couldn't read that",
+                    subtitle = "The model couldn't find an expression in the photo.",
+                    icon = Icons.Default.ErrorOutline,
+                    tint = MaterialTheme.colorScheme.error,
+                    titleColor = MaterialTheme.colorScheme.error
+                )
+                AiCard(
+                    modifier = Modifier.fillMaxWidth(),
+                    colors = CardDefaults.elevatedCardColors(
+                        containerColor = MaterialTheme.colorScheme.errorContainer.copy(alpha = 0.4f)
+                    )
+                ) {
+                    Text("raw model output…", style = MaterialTheme.typography.bodySmall, modifier = Modifier.padding(12.dp))
+                }
+            }
+        }
+    }
+}
+
+@Preview(name = "Downloading", showBackground = true)
+@Composable
+private fun DownloadingPreview() {
+    CalculatorM3Theme {
+        Surface {
+            Column(
+                Modifier.fillMaxSize().padding(32.dp),
+                horizontalAlignment = Alignment.CenterHorizontally,
+                verticalArrangement = Arrangement.spacedBy(16.dp)
+            ) {
+                AiHero(title = "Downloading AI model", icon = Icons.Default.CloudDownload, pulsing = true)
+                AiDownloadBar(progress = 0.42f, modifier = Modifier.fillMaxWidth())
+                Text("1.3 GB / 3.1 GB (42%)", style = MaterialTheme.typography.bodySmall)
+            }
+        }
+    }
+}
+
+@Preview(name = "Shimmer skeleton", showBackground = true)
+@Composable
+private fun ShimmerPreview() {
+    CalculatorM3Theme {
+        Surface {
+            AiCard(Modifier.fillMaxWidth().padding(24.dp)) {
+                ShimmerLines(Modifier.padding(16.dp))
+            }
+        }
+    }
+}

--- a/app/src/main/java/com/vagujhelyigergely/calculatorm3/CalculatorScreen.kt
+++ b/app/src/main/java/com/vagujhelyigergely/calculatorm3/CalculatorScreen.kt
@@ -20,6 +20,7 @@ import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.filled.AccessTime
 import androidx.compose.material.icons.filled.CameraAlt
 import androidx.compose.material.icons.filled.DeleteOutline
+import androidx.compose.material.icons.filled.Psychology
 import androidx.compose.material3.*
 import androidx.compose.runtime.*
 import androidx.compose.runtime.saveable.rememberSaveable
@@ -165,6 +166,7 @@ fun CalculatorScreen(
     if (showAiWarningDialog) {
         AlertDialog(
             onDismissRequest = { showAiWarningDialog = false },
+            icon = { Icon(imageVector = Icons.Default.Psychology, contentDescription = null) },
             title = { Text(text = stringResource(R.string.experimental_feature_title)) },
             text = { Text(text = stringResource(R.string.experimental_feature_warning)) },
             confirmButton = {

--- a/app/src/main/java/com/vagujhelyigergely/calculatorm3/camera/CameraScanScreen.kt
+++ b/app/src/main/java/com/vagujhelyigergely/calculatorm3/camera/CameraScanScreen.kt
@@ -57,6 +57,7 @@ import androidx.compose.ui.hapticfeedback.HapticFeedbackType
 import androidx.compose.ui.input.nestedscroll.nestedScroll
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.platform.LocalHapticFeedback
+import androidx.compose.ui.platform.LocalLayoutDirection
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.text.style.TextAlign
@@ -767,10 +768,16 @@ private fun ModelSelectionContent(
         }
     ) { innerPadding ->
         LazyColumn(
-            modifier = Modifier
-                .fillMaxSize()
-                .padding(innerPadding),
-            contentPadding = PaddingValues(start = 24.dp, end = 24.dp, top = 8.dp, bottom = 24.dp),
+            modifier = Modifier.fillMaxSize(),
+            // Fold the Scaffold insets into contentPadding (rather than Modifier.padding) so the
+            // list fills the screen and items scroll behind the translucent nav bar, while the
+            // first/last items stay clear of the app bar and system bars (incl. landscape cutouts).
+            contentPadding = PaddingValues(
+                start = 24.dp + innerPadding.calculateStartPadding(LocalLayoutDirection.current),
+                end = 24.dp + innerPadding.calculateEndPadding(LocalLayoutDirection.current),
+                top = 8.dp + innerPadding.calculateTopPadding(),
+                bottom = 24.dp + innerPadding.calculateBottomPadding()
+            ),
             verticalArrangement = Arrangement.spacedBy(12.dp)
         ) {
             item {
@@ -783,14 +790,14 @@ private fun ModelSelectionContent(
             }
             if (gemma4Models.isNotEmpty()) {
                 item { ModelGroupHeader(stringResource(R.string.models_group_gemma4)) }
-                items(gemma4Models) { model ->
+                items(gemma4Models, key = { it.id }) { model ->
                     ModelCard(model, model in downloadedModels, model == selectedModel,
                         model.minRamGb > deviceRamGb, deviceRamGb, onSelectModel, onDownloadModel)
                 }
             }
             if (loginModels.isNotEmpty()) {
                 item { ModelGroupHeader(stringResource(R.string.models_group_login)) }
-                items(loginModels) { model ->
+                items(loginModels, key = { it.id }) { model ->
                     ModelCard(model, model in downloadedModels, model == selectedModel,
                         model.minRamGb > deviceRamGb, deviceRamGb, onSelectModel, onDownloadModel)
                 }
@@ -868,7 +875,7 @@ private fun ModelCard(
                 .fillMaxWidth(),
             verticalAlignment = Alignment.CenterVertically
         ) {
-            Column(modifier = Modifier.weight(1f).animateContentSize()) {
+            Column(modifier = Modifier.weight(1f)) {
                 Text(
                     text = model.displayName,
                     style = MaterialTheme.typography.titleMedium,

--- a/app/src/main/java/com/vagujhelyigergely/calculatorm3/camera/CameraScanScreen.kt
+++ b/app/src/main/java/com/vagujhelyigergely/calculatorm3/camera/CameraScanScreen.kt
@@ -1,3 +1,5 @@
+@file:OptIn(ExperimentalSharedTransitionApi::class, ExperimentalMaterial3Api::class)
+
 package com.vagujhelyigergely.calculatorm3.camera
 
 import android.Manifest
@@ -9,18 +11,31 @@ import androidx.activity.compose.rememberLauncherForActivityResult
 import androidx.activity.result.PickVisualMediaRequest
 import androidx.activity.result.contract.ActivityResultContracts
 import androidx.core.content.FileProvider
-import androidx.compose.animation.core.*
-import androidx.compose.foundation.background
-import androidx.compose.foundation.border
+import androidx.compose.animation.AnimatedContent
+import androidx.compose.animation.AnimatedVisibility
+import androidx.compose.animation.ExperimentalSharedTransitionApi
+import androidx.compose.animation.SharedTransitionLayout
+import androidx.compose.animation.animateColorAsState
+import androidx.compose.animation.animateContentSize
+import androidx.compose.animation.core.Spring
+import androidx.compose.animation.core.animateFloatAsState
+import androidx.compose.animation.core.spring
+import androidx.compose.animation.core.tween
+import androidx.compose.animation.fadeIn
+import androidx.compose.animation.fadeOut
+import androidx.compose.animation.scaleIn
+import androidx.compose.animation.togetherWith
+import androidx.compose.foundation.BorderStroke
+import androidx.compose.foundation.interaction.MutableInteractionSource
+import androidx.compose.foundation.interaction.collectIsPressedAsState
 import androidx.compose.foundation.layout.*
+import androidx.compose.foundation.lazy.LazyColumn
+import androidx.compose.foundation.lazy.items
 import androidx.compose.foundation.rememberScrollState
 import androidx.compose.foundation.verticalScroll
-import androidx.compose.foundation.shape.CircleShape
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material.icons.Icons
-import androidx.compose.material.icons.filled.CameraAlt
 import androidx.compose.material.icons.filled.CheckCircle
-import androidx.compose.material.icons.filled.Close
 import androidx.compose.material.icons.filled.CloudDownload
 import androidx.compose.material.icons.filled.ErrorOutline
 import androidx.compose.material.icons.filled.ExpandLess
@@ -29,18 +44,19 @@ import androidx.compose.material.icons.filled.ExpandMore
 import androidx.compose.material.icons.filled.PhotoCamera
 import androidx.compose.material.icons.filled.PhotoLibrary
 import androidx.compose.material.icons.filled.Psychology
-import androidx.compose.material.icons.filled.Storage
 import androidx.compose.material.icons.filled.SwapHoriz
 import androidx.compose.material3.*
 import androidx.compose.runtime.*
 import androidx.compose.runtime.saveable.rememberSaveable
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
-import androidx.compose.ui.draw.clip
 import androidx.compose.ui.graphics.graphicsLayer
 import androidx.compose.ui.graphics.vector.ImageVector
 import android.view.WindowManager
+import androidx.compose.ui.hapticfeedback.HapticFeedbackType
+import androidx.compose.ui.input.nestedscroll.nestedScroll
 import androidx.compose.ui.platform.LocalContext
+import androidx.compose.ui.platform.LocalHapticFeedback
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.text.style.TextAlign
@@ -50,7 +66,6 @@ import androidx.compose.ui.platform.LocalDensity
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
 import androidx.compose.ui.viewinterop.AndroidView
-import androidx.compose.ui.zIndex
 import io.noties.markwon.Markwon
 import io.noties.markwon.ext.latex.JLatexMathPlugin
 import io.noties.markwon.inlineparser.MarkwonInlineParserPlugin
@@ -114,126 +129,152 @@ fun CameraScanScreen(
             modifier = Modifier.fillMaxSize(),
             color = MaterialTheme.colorScheme.surface
         ) {
-            run {
-                when (val state = viewModel.uiState) {
-                    is ScanUiState.Idle -> StatusContent(
-                        icon = Icons.Default.Psychology,
-                        title = stringResource(R.string.initializing),
-                        subtitle = null,
-                        showProgress = true,
-                        onDismiss = onDismiss
-                    )
-                    is ScanUiState.ModelLoading -> ModelLoadingContent(
-                        startTimeMs = state.startTimeMs,
-                        onDismiss = onDismiss
-                    )
-                    is ScanUiState.Capturing -> CameraContent(
-                        modelName = viewModel.selectedModelName,
-                        onPhotoCaptured = { path -> viewModel.onPhotoCaptured(path) },
-                        onCaptureError = { msg -> viewModel.onCaptureError(msg) },
-                        onSwitchModel = { viewModel.showModelSelection() },
-                        onDismiss = onDismiss
-                    )
-                    is ScanUiState.Processing -> ProcessingContent(
-                        partialRaw = state.partialRaw,
-                        startTimeMs = state.startTimeMs,
-                        tokenCount = state.tokenCount,
-                        backend = state.backend,
-                        firstTokenMs = state.firstTokenMs,
-                        onDismiss = onDismiss
-                    )
-                    is ScanUiState.Success -> SuccessContent(
-                        answer = state.answer,
-                        rawResponse = state.rawResponse,
-                        elapsedMs = state.elapsedMs,
-                        tokenCount = state.tokenCount,
-                        backend = state.backend,
-                        ttftMs = state.ttftMs,
-                        decodeTokensPerSec = state.decodeTokensPerSec,
-                        onUse = {
-                            onExpressionRecognized(state.answer)
-                            onDismiss()
-                        },
-                        onRetry = { viewModel.retry() },
-                        onDismiss = onDismiss
-                    )
-                    is ScanUiState.Error -> ErrorContent(
-                        message = state.message,
-                        rawResponse = state.rawResponse,
-                        onRetry = { viewModel.retry() },
-                        onDismiss = onDismiss
-                    )
-                    is ScanUiState.FirstTimeWarning -> FirstTimeWarningContent(
-                        onContinue = { viewModel.showModelSelection() },
-                        onDismiss = onDismiss
-                    )
-                    is ScanUiState.MobileDataWarning -> MobileDataWarningContent(
-                        model = state.model,
-                        onContinue = { viewModel.confirmMobileDataDownload(state.model) },
-                        onCancel = { viewModel.showModelSelection() },
-                        onDismiss = onDismiss
-                    )
-                    is ScanUiState.AuthError -> AuthErrorContent(
-                        httpCode = state.httpCode,
-                        model = state.model,
-                        onRetry = { viewModel.startDownload(state.model) },
-                        onReauth = { viewModel.showSignIn(state.model) },
-                        onDismiss = onDismiss
-                    )
-                    is ScanUiState.SignInRequired -> SignInContent(
-                        model = state.model,
-                        onSignIn = { signInLauncher.launch(viewModel.signInIntentFor(state.model)) },
-                        onDismiss = onDismiss
-                    )
-                    is ScanUiState.Authenticating -> StatusContent(
-                        icon = Icons.AutoMirrored.Filled.Login,
-                        title = stringResource(R.string.signing_in),
-                        subtitle = null,
-                        showProgress = true,
-                        onDismiss = onDismiss
-                    )
-                    is ScanUiState.Downloading -> DownloadingContent(
-                        currentFile = state.currentFile,
-                        downloadedBytes = state.downloadedBytes,
-                        totalBytes = state.totalBytes,
-                        fileIndex = state.fileIndex,
-                        fileCount = state.fileCount,
-                        onCancel = { viewModel.cancelDownload() },
-                        onDismiss = onDismiss
-                    )
-                    is ScanUiState.DownloadComplete -> StatusContent(
-                        icon = Icons.Default.CheckCircle,
-                        title = stringResource(R.string.download_complete),
-                        subtitle = stringResource(R.string.model_loading),
-                        showProgress = true,
-                        onDismiss = onDismiss
-                    )
-                    is ScanUiState.ModelSelection -> ModelSelectionContent(
-                        selectedModel = state.selectedModel,
-                        downloadedModels = state.downloadedModels,
-                        deviceRamGb = state.deviceRamGb,
-                        onSelectModel = { viewModel.selectModel(it) },
-                        onDownloadModel = { viewModel.startDownload(it) },
-                        onDismiss = onDismiss
-                    )
+            // One SharedTransitionLayout + AnimatedContent drive every state change: states
+            // cross-fade/scale into each other and tagged elements (the close button, the hero
+            // icon/title, the answer card) morph across states instead of cutting. The content
+            // key is coarse so streaming/progress updates (new Processing/Downloading instances
+            // on every token/byte) recompose in place rather than replaying the transition.
+            SharedTransitionLayout {
+                AnimatedContent(
+                    targetState = viewModel.uiState,
+                    contentKey = { it.screenKey() },
+                    transitionSpec = {
+                        (fadeIn(animationSpec = tween(240)) +
+                            scaleIn(initialScale = 0.94f, animationSpec = tween(240))) togetherWith
+                            fadeOut(animationSpec = tween(160))
+                    },
+                    label = "scanState"
+                ) { state ->
+                    CompositionLocalProvider(
+                        LocalSharedTransitionScope provides this@SharedTransitionLayout,
+                        LocalAiVisibilityScope provides this@AnimatedContent
+                    ) {
+                        when (state) {
+                            is ScanUiState.Idle -> StatusContent(
+                                title = stringResource(R.string.initializing),
+                                subtitle = null,
+                                onDismiss = onDismiss
+                            )
+                            is ScanUiState.ModelLoading -> ModelLoadingContent(
+                                startTimeMs = state.startTimeMs,
+                                onDismiss = onDismiss
+                            )
+                            is ScanUiState.Capturing -> CameraContent(
+                                modelName = viewModel.selectedModelName,
+                                onPhotoCaptured = { path -> viewModel.onPhotoCaptured(path) },
+                                onCaptureError = { msg -> viewModel.onCaptureError(msg) },
+                                onSwitchModel = { viewModel.showModelSelection() },
+                                onDismiss = onDismiss
+                            )
+                            is ScanUiState.Processing -> ProcessingContent(
+                                partialRaw = state.partialRaw,
+                                startTimeMs = state.startTimeMs,
+                                tokenCount = state.tokenCount,
+                                backend = state.backend,
+                                firstTokenMs = state.firstTokenMs,
+                                onDismiss = onDismiss
+                            )
+                            is ScanUiState.Success -> SuccessContent(
+                                answer = state.answer,
+                                rawResponse = state.rawResponse,
+                                elapsedMs = state.elapsedMs,
+                                tokenCount = state.tokenCount,
+                                backend = state.backend,
+                                ttftMs = state.ttftMs,
+                                decodeTokensPerSec = state.decodeTokensPerSec,
+                                onUse = {
+                                    onExpressionRecognized(state.answer)
+                                    onDismiss()
+                                },
+                                onRetry = { viewModel.retry() },
+                                onDismiss = onDismiss
+                            )
+                            is ScanUiState.Error -> ErrorContent(
+                                message = state.message,
+                                rawResponse = state.rawResponse,
+                                onRetry = { viewModel.retry() },
+                                onDismiss = onDismiss
+                            )
+                            is ScanUiState.FirstTimeWarning -> FirstTimeWarningContent(
+                                onContinue = { viewModel.showModelSelection() },
+                                onDismiss = onDismiss
+                            )
+                            is ScanUiState.MobileDataWarning -> MobileDataWarningContent(
+                                model = state.model,
+                                onContinue = { viewModel.confirmMobileDataDownload(state.model) },
+                                onCancel = { viewModel.showModelSelection() },
+                                onDismiss = onDismiss
+                            )
+                            is ScanUiState.AuthError -> AuthErrorContent(
+                                httpCode = state.httpCode,
+                                model = state.model,
+                                onRetry = { viewModel.startDownload(state.model) },
+                                onReauth = { viewModel.showSignIn(state.model) },
+                                onDismiss = onDismiss
+                            )
+                            is ScanUiState.SignInRequired -> SignInContent(
+                                model = state.model,
+                                onSignIn = { signInLauncher.launch(viewModel.signInIntentFor(state.model)) },
+                                onDismiss = onDismiss
+                            )
+                            is ScanUiState.Authenticating -> StatusContent(
+                                title = stringResource(R.string.signing_in),
+                                subtitle = null,
+                                onDismiss = onDismiss
+                            )
+                            is ScanUiState.Downloading -> DownloadingContent(
+                                currentFile = state.currentFile,
+                                downloadedBytes = state.downloadedBytes,
+                                totalBytes = state.totalBytes,
+                                fileIndex = state.fileIndex,
+                                fileCount = state.fileCount,
+                                onCancel = { viewModel.cancelDownload() },
+                                onDismiss = onDismiss
+                            )
+                            is ScanUiState.DownloadComplete -> StatusContent(
+                                title = stringResource(R.string.download_complete),
+                                subtitle = stringResource(R.string.model_loading),
+                                onDismiss = onDismiss,
+                                icon = Icons.Default.CheckCircle,
+                                loading = false
+                            )
+                            is ScanUiState.ModelSelection -> ModelSelectionContent(
+                                selectedModel = state.selectedModel,
+                                downloadedModels = state.downloadedModels,
+                                deviceRamGb = state.deviceRamGb,
+                                onSelectModel = { viewModel.selectModel(it) },
+                                onDownloadModel = { viewModel.startDownload(it) },
+                                onDismiss = onDismiss
+                            )
+                        }
+                    }
                 }
             }
         }
     }
 }
 
-@Composable
-private fun CloseButton(onDismiss: () -> Unit, modifier: Modifier = Modifier) {
-    IconButton(
-        onClick = onDismiss,
-        modifier = modifier
-    ) {
-        Icon(
-            imageVector = Icons.Default.Close,
-            contentDescription = stringResource(R.string.close),
-            tint = MaterialTheme.colorScheme.onSurface
-        )
-    }
+/**
+ * Coarse, stable identity per screen so [AnimatedContent] only animates real screen
+ * changes. Crucially, Processing and Downloading collapse to a single key each: their
+ * state object is replaced on every streamed token / progress tick, and we don't want
+ * the enter/exit transition to replay each time.
+ */
+private fun ScanUiState.screenKey(): Any = when (this) {
+    is ScanUiState.Idle -> "idle"
+    is ScanUiState.ModelLoading -> "modelLoading"
+    is ScanUiState.Capturing -> "capturing"
+    is ScanUiState.Processing -> "processing"
+    is ScanUiState.Success -> "success"
+    is ScanUiState.Error -> "error"
+    is ScanUiState.ModelSelection -> "modelSelection"
+    is ScanUiState.Downloading -> "downloading"
+    is ScanUiState.DownloadComplete -> "downloadComplete"
+    is ScanUiState.SignInRequired -> "signIn"
+    is ScanUiState.Authenticating -> "authenticating"
+    is ScanUiState.AuthError -> "authError"
+    is ScanUiState.FirstTimeWarning -> "firstTime"
+    is ScanUiState.MobileDataWarning -> "mobileData"
 }
 
 /** Elapsed time counter that updates every second. */
@@ -253,93 +294,42 @@ private fun ElapsedTimeText(startTimeMs: Long) {
     )
 }
 
-/** Generic status screen with icon, title, optional subtitle and progress. */
+/** Generic centered status screen: a hero (expressive loader or icon) plus optional subtitle. */
 @Composable
 private fun StatusContent(
-    icon: ImageVector,
     title: String,
     subtitle: String?,
-    showProgress: Boolean,
-    onDismiss: () -> Unit
+    onDismiss: () -> Unit,
+    icon: ImageVector? = null,
+    loading: Boolean = true
 ) {
-    Box(modifier = Modifier.fillMaxSize().navigationBarsPadding()) {
-        CloseButton(
-            onDismiss = onDismiss,
-            modifier = Modifier
-                .align(Alignment.TopStart)
-                .statusBarsPadding()
-                .padding(8.dp)
-        )
-        Column(
+    AiStateScaffold(onDismiss = onDismiss) {
+        AiHero(
+            title = title,
+            subtitle = subtitle,
+            icon = icon,
+            loading = loading,
             modifier = Modifier
                 .align(Alignment.Center)
-                .padding(32.dp),
-            horizontalAlignment = Alignment.CenterHorizontally,
-            verticalArrangement = Arrangement.spacedBy(16.dp)
-        ) {
-            Icon(
-                imageVector = icon,
-                contentDescription = null,
-                modifier = Modifier.size(48.dp),
-                tint = MaterialTheme.colorScheme.primary
-            )
-            Text(text = title, style = MaterialTheme.typography.titleMedium)
-            if (subtitle != null) {
-                Text(
-                    text = subtitle,
-                    style = MaterialTheme.typography.bodyMedium,
-                    color = MaterialTheme.colorScheme.onSurfaceVariant,
-                    textAlign = TextAlign.Center
-                )
-            }
-            if (showProgress) {
-                LinearProgressIndicator(
-                    modifier = Modifier
-                        .fillMaxWidth()
-                        .padding(horizontal = 32.dp)
-                )
-            }
-        }
+                .padding(32.dp)
+        )
     }
 }
 
 @Composable
 private fun ModelLoadingContent(startTimeMs: Long, onDismiss: () -> Unit) {
-    Box(modifier = Modifier.fillMaxSize().navigationBarsPadding()) {
-        CloseButton(
-            onDismiss = onDismiss,
-            modifier = Modifier
-                .align(Alignment.TopStart)
-                .statusBarsPadding()
-                .padding(8.dp)
-        )
+    AiStateScaffold(onDismiss = onDismiss) {
         Column(
             modifier = Modifier
                 .align(Alignment.Center)
                 .padding(32.dp),
             horizontalAlignment = Alignment.CenterHorizontally,
-            verticalArrangement = Arrangement.spacedBy(16.dp)
+            verticalArrangement = Arrangement.spacedBy(12.dp)
         ) {
-            Icon(
-                imageVector = Icons.Default.Storage,
-                contentDescription = null,
-                modifier = Modifier.size(48.dp),
-                tint = MaterialTheme.colorScheme.primary
-            )
-            Text(
-                text = stringResource(R.string.model_loading),
-                style = MaterialTheme.typography.titleMedium
-            )
-            Text(
-                text = stringResource(R.string.model_loading_hint),
-                style = MaterialTheme.typography.bodyMedium,
-                color = MaterialTheme.colorScheme.onSurfaceVariant,
-                textAlign = TextAlign.Center
-            )
-            LinearProgressIndicator(
-                modifier = Modifier
-                    .fillMaxWidth()
-                    .padding(horizontal = 32.dp)
+            AiHero(
+                title = stringResource(R.string.model_loading),
+                subtitle = stringResource(R.string.model_loading_hint),
+                loading = true
             )
             ElapsedTimeText(startTimeMs = startTimeMs)
         }
@@ -357,84 +347,49 @@ private fun ProcessingContent(
 ) {
     val isGenerating = partialRaw.isNotEmpty()
 
-    // Pulsing icon
-    val infiniteTransition = rememberInfiniteTransition(label = "pulse")
-    val scale by infiniteTransition.animateFloat(
-        initialValue = 1f,
-        targetValue = 1.15f,
-        animationSpec = infiniteRepeatable(
-            animation = tween(800, easing = EaseInOutSine),
-            repeatMode = RepeatMode.Reverse
-        ),
-        label = "pulse_scale"
-    )
-
-    Box(modifier = Modifier.fillMaxSize().navigationBarsPadding()) {
-        CloseButton(
-            onDismiss = onDismiss,
-            modifier = Modifier
-                .align(Alignment.TopStart)
-                .statusBarsPadding()
-                .padding(8.dp)
-        )
+    AiStateScaffold(onDismiss = onDismiss) {
         Column(
             modifier = Modifier
                 .align(Alignment.Center)
+                .fillMaxWidth()
                 .padding(horizontal = 32.dp),
             horizontalAlignment = Alignment.CenterHorizontally,
-            verticalArrangement = Arrangement.spacedBy(16.dp)
+            verticalArrangement = Arrangement.spacedBy(20.dp)
         ) {
-            Icon(
-                imageVector = Icons.Default.Psychology,
-                contentDescription = null,
-                modifier = Modifier
-                    .size(48.dp)
-                    .graphicsLayer(scaleX = scale, scaleY = scale),
-                tint = MaterialTheme.colorScheme.primary
+            AiHero(
+                title = if (isGenerating)
+                    stringResource(R.string.camera_generating)
+                else
+                    stringResource(R.string.camera_processing_image),
+                subtitle = if (isGenerating) null else stringResource(R.string.processing_image_hint),
+                icon = Icons.Default.Psychology,
+                pulsing = true
             )
 
-            if (!isGenerating) {
-                // Phase 1: processing image (prefill) — no tokens yet
-                Text(
-                    text = stringResource(R.string.camera_processing_image),
-                    style = MaterialTheme.typography.titleMedium
-                )
-                Text(
-                    text = stringResource(R.string.processing_image_hint),
-                    style = MaterialTheme.typography.bodyMedium,
-                    color = MaterialTheme.colorScheme.onSurfaceVariant,
-                    textAlign = TextAlign.Center
-                )
-                LinearProgressIndicator(
-                    modifier = Modifier
-                        .fillMaxWidth()
-                        .padding(horizontal = 16.dp)
-                )
-            } else {
-                // Phase 2: generating tokens — show streaming output
-                Text(
-                    text = stringResource(R.string.camera_generating),
-                    style = MaterialTheme.typography.titleMedium
-                )
-                val scrollState = rememberScrollState()
-                LaunchedEffect(partialRaw) {
-                    scrollState.animateScrollTo(scrollState.maxValue)
-                }
-                Surface(
-                    modifier = Modifier
-                        .fillMaxWidth()
-                        .heightIn(max = 300.dp),
-                    shape = RoundedCornerShape(8.dp),
-                    color = MaterialTheme.colorScheme.surfaceVariant,
-                    tonalElevation = 1.dp
-                ) {
+            // One card spans the whole "answer" lifecycle: a shimmering skeleton while the
+            // model prefills the image (no tokens yet), then the live streaming text. Tagged
+            // as the shared "answer-card" so it morphs straight into the Success result card.
+            val scrollState = rememberScrollState()
+            LaunchedEffect(partialRaw) {
+                scrollState.animateScrollTo(scrollState.maxValue)
+            }
+            AiCard(
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .heightIn(max = 300.dp)
+                    .aiSharedBounds("answer-card")
+                    .animateContentSize()
+            ) {
+                if (isGenerating) {
                     Text(
                         text = partialRaw,
                         style = MaterialTheme.typography.bodyMedium,
                         modifier = Modifier
-                            .padding(12.dp)
+                            .padding(16.dp)
                             .verticalScroll(scrollState)
                     )
+                } else {
+                    ShimmerLines(modifier = Modifier.padding(16.dp))
                 }
             }
 
@@ -463,11 +418,17 @@ private fun PerfHud(startTimeMs: Long, tokenCount: Int, backend: String, firstTo
         val decodeTps = if (tokenCount > 1 && decodeSecs > 0.05) (tokenCount - 1) / decodeSecs else 0.0
         "%s · %.1f tok/s · ttft %.1fs".format(label, decodeTps, ttftSecs)
     }
-    Text(
-        text = text,
-        style = MaterialTheme.typography.bodySmall,
-        color = MaterialTheme.colorScheme.primary
-    )
+    Surface(
+        shape = RoundedCornerShape(percent = 50),
+        color = MaterialTheme.colorScheme.surfaceContainerHighest
+    ) {
+        Text(
+            text = text,
+            style = MaterialTheme.typography.labelSmall,
+            color = MaterialTheme.colorScheme.onSurfaceVariant,
+            modifier = Modifier.padding(horizontal = 12.dp, vertical = 6.dp)
+        )
+    }
 }
 
 @Composable
@@ -510,53 +471,37 @@ private fun CameraContent(
         }
     }
 
-    Box(modifier = Modifier.fillMaxSize().navigationBarsPadding()) {
-        // Top bar: close + model switch
-        Row(
-            modifier = Modifier
-                .align(Alignment.TopStart)
-                .fillMaxWidth()
-                .statusBarsPadding()
-                .padding(8.dp),
-            horizontalArrangement = Arrangement.SpaceBetween,
-            verticalAlignment = Alignment.CenterVertically
-        ) {
-            CloseButton(onDismiss = onDismiss)
-            TextButton(onClick = onSwitchModel) {
+    AiStateScaffold(onDismiss = onDismiss) {
+        // Model switcher, top-end (close button is supplied by the scaffold, top-start).
+        AssistChip(
+            onClick = onSwitchModel,
+            label = { Text(text = modelName, style = MaterialTheme.typography.labelLarge) },
+            leadingIcon = {
                 Icon(
                     imageVector = Icons.Default.SwapHoriz,
                     contentDescription = null,
                     modifier = Modifier.size(18.dp)
                 )
-                Spacer(modifier = Modifier.width(4.dp))
-                Text(
-                    text = modelName,
-                    style = MaterialTheme.typography.bodySmall
-                )
-            }
-        }
+            },
+            modifier = Modifier
+                .align(Alignment.TopEnd)
+                .statusBarsPadding()
+                .padding(8.dp)
+        )
 
-        // Centered prompt + capture/pick actions
         Column(
             modifier = Modifier
                 .align(Alignment.Center)
+                .fillMaxWidth()
                 .padding(horizontal = 32.dp),
-            horizontalAlignment = Alignment.CenterHorizontally
+            horizontalAlignment = Alignment.CenterHorizontally,
+            verticalArrangement = Arrangement.spacedBy(20.dp)
         ) {
-            Icon(
-                imageVector = Icons.Default.PhotoCamera,
-                contentDescription = null,
-                tint = MaterialTheme.colorScheme.primary,
-                modifier = Modifier.size(64.dp)
+            AiHero(
+                title = stringResource(R.string.scan_hint),
+                icon = Icons.Default.PhotoCamera
             )
-            Spacer(modifier = Modifier.height(20.dp))
-            Text(
-                text = stringResource(R.string.scan_hint),
-                color = MaterialTheme.colorScheme.onSurface,
-                fontSize = 16.sp,
-                textAlign = TextAlign.Center
-            )
-            Spacer(modifier = Modifier.height(32.dp))
+            Spacer(modifier = Modifier.height(12.dp))
             Button(
                 onClick = {
                     val file = File(context.cacheDir, "scan_${System.currentTimeMillis()}.jpg")
@@ -573,7 +518,6 @@ private fun CameraContent(
                 Spacer(modifier = Modifier.width(8.dp))
                 Text(text = stringResource(R.string.take_photo))
             }
-            Spacer(modifier = Modifier.height(12.dp))
             OutlinedButton(
                 onClick = {
                     pickImageLauncher.launch(
@@ -667,15 +611,7 @@ private fun SuccessContent(
     onRetry: () -> Unit,
     onDismiss: () -> Unit
 ) {
-    Box(modifier = Modifier.fillMaxSize().navigationBarsPadding()) {
-        CloseButton(
-            onDismiss = onDismiss,
-            modifier = Modifier
-                .align(Alignment.TopStart)
-                .statusBarsPadding()
-                .padding(8.dp)
-                .zIndex(1f)
-        )
+    AiStateScaffold(onDismiss = onDismiss) {
         Column(
             modifier = Modifier
                 .align(Alignment.Center)
@@ -686,23 +622,13 @@ private fun SuccessContent(
             horizontalAlignment = Alignment.CenterHorizontally,
             verticalArrangement = Arrangement.spacedBy(20.dp)
         ) {
-            Icon(
-                imageVector = Icons.Default.CheckCircle,
-                contentDescription = null,
-                modifier = Modifier.size(48.dp),
-                tint = MaterialTheme.colorScheme.primary
+            AiHero(
+                title = stringResource(R.string.answer_found),
+                icon = Icons.Default.CheckCircle
             )
-            Text(
-                text = stringResource(R.string.answer_found),
-                style = MaterialTheme.typography.titleMedium
-            )
-            // The model's full answer, rendered with markdown + LaTeX math.
-            Surface(
-                modifier = Modifier.fillMaxWidth(),
-                shape = RoundedCornerShape(12.dp),
-                color = MaterialTheme.colorScheme.surfaceVariant,
-                tonalElevation = 1.dp
-            ) {
+            // The model's full answer (markdown + LaTeX). Shares the "answer-card" bounds with
+            // the Processing card, so the streaming text morphs into this result.
+            AiCard(modifier = Modifier.fillMaxWidth().aiSharedBounds("answer-card")) {
                 MarkdownLatexText(
                     text = rawResponse.trim(),
                     color = MaterialTheme.colorScheme.onSurface,
@@ -752,36 +678,22 @@ private fun ErrorContent(
 ) {
     var showRaw by remember { mutableStateOf(false) }
 
-    Box(modifier = Modifier.fillMaxSize().navigationBarsPadding()) {
-        CloseButton(
-            onDismiss = onDismiss,
-            modifier = Modifier
-                .align(Alignment.TopStart)
-                .statusBarsPadding()
-                .padding(8.dp)
-        )
+    AiStateScaffold(onDismiss = onDismiss) {
         Column(
             modifier = Modifier
                 .align(Alignment.Center)
-                .padding(32.dp),
+                .fillMaxWidth()
+                .padding(32.dp)
+                .animateContentSize(),
             horizontalAlignment = Alignment.CenterHorizontally,
             verticalArrangement = Arrangement.spacedBy(16.dp)
         ) {
-            Icon(
-                imageVector = Icons.Default.ErrorOutline,
-                contentDescription = null,
-                modifier = Modifier.size(48.dp),
-                tint = MaterialTheme.colorScheme.error
-            )
-            Text(
-                text = stringResource(R.string.recognition_error),
-                style = MaterialTheme.typography.titleMedium,
-                color = MaterialTheme.colorScheme.error
-            )
-            Text(
-                text = message,
-                style = MaterialTheme.typography.bodyMedium,
-                textAlign = TextAlign.Center
+            AiHero(
+                title = stringResource(R.string.recognition_error),
+                subtitle = message,
+                icon = Icons.Default.ErrorOutline,
+                tint = MaterialTheme.colorScheme.error,
+                titleColor = MaterialTheme.colorScheme.error
             )
             OutlinedButton(onClick = onRetry) {
                 Text(stringResource(R.string.retry))
@@ -798,14 +710,14 @@ private fun ErrorContent(
                         modifier = Modifier.size(18.dp)
                     )
                 }
-                if (showRaw) {
-                    Surface(
+                AnimatedVisibility(visible = showRaw) {
+                    AiCard(
                         modifier = Modifier
                             .fillMaxWidth()
                             .padding(horizontal = 8.dp),
-                        shape = RoundedCornerShape(8.dp),
-                        color = MaterialTheme.colorScheme.surfaceVariant,
-                        tonalElevation = 1.dp
+                        colors = CardDefaults.elevatedCardColors(
+                            containerColor = MaterialTheme.colorScheme.errorContainer.copy(alpha = 0.4f)
+                        )
                     ) {
                         Text(
                             text = rawResponse,
@@ -828,58 +740,57 @@ private fun ModelSelectionContent(
     onDownloadModel: (AiModel) -> Unit,
     onDismiss: () -> Unit
 ) {
-    Box(modifier = Modifier.fillMaxSize().navigationBarsPadding()) {
-        CloseButton(
-            onDismiss = onDismiss,
-            modifier = Modifier
-                .align(Alignment.TopStart)
-                .statusBarsPadding()
-                .padding(8.dp)
-        )
-        Column(
+    val scrollBehavior = TopAppBarDefaults.exitUntilCollapsedScrollBehavior(rememberTopAppBarState())
+
+    // Two top-level groups: the Gemma 4 models (no account needed) and the gated models
+    // that need a HuggingFace login. Today these coincide exactly with the requiresAuth split.
+    val gemma4Models = AiModel.entries.filter { !it.requiresAuth }
+    val loginModels = AiModel.entries.filter { it.requiresAuth }
+
+    Scaffold(
+        modifier = Modifier
+            .fillMaxSize()
+            .nestedScroll(scrollBehavior.nestedScrollConnection),
+        containerColor = MaterialTheme.colorScheme.surface,
+        topBar = {
+            LargeTopAppBar(
+                title = { Text(stringResource(R.string.choose_model)) },
+                navigationIcon = {
+                    CloseButton(onDismiss = onDismiss, modifier = Modifier.aiSharedElement("close"))
+                },
+                scrollBehavior = scrollBehavior,
+                colors = TopAppBarDefaults.largeTopAppBarColors(
+                    containerColor = MaterialTheme.colorScheme.surface,
+                    scrolledContainerColor = MaterialTheme.colorScheme.surfaceContainer
+                )
+            )
+        }
+    ) { innerPadding ->
+        LazyColumn(
             modifier = Modifier
                 .fillMaxSize()
-                .statusBarsPadding()
-                .padding(horizontal = 24.dp)
-                .padding(top = 56.dp, bottom = 16.dp)
-                .verticalScroll(rememberScrollState()),
-            horizontalAlignment = Alignment.CenterHorizontally,
+                .padding(innerPadding),
+            contentPadding = PaddingValues(start = 24.dp, end = 24.dp, top = 8.dp, bottom = 24.dp),
             verticalArrangement = Arrangement.spacedBy(12.dp)
         ) {
-            Icon(
-                imageVector = Icons.Default.Psychology,
-                contentDescription = null,
-                modifier = Modifier.size(48.dp),
-                tint = MaterialTheme.colorScheme.primary
-            )
-            Text(
-                text = stringResource(R.string.choose_model),
-                style = MaterialTheme.typography.titleMedium
-            )
-            Text(
-                text = stringResource(R.string.choose_model_description, deviceRamGb),
-                style = MaterialTheme.typography.bodySmall,
-                color = MaterialTheme.colorScheme.onSurfaceVariant,
-                textAlign = TextAlign.Center
-            )
-
-            // Two top-level groups: the Gemma 4 models (no account needed) and the gated
-            // models that need a HuggingFace login. Today these coincide exactly with the
-            // requiresAuth split.
-            val gemma4Models = AiModel.entries.filter { !it.requiresAuth }
-            val loginModels = AiModel.entries.filter { it.requiresAuth }
-
+            item {
+                AiHint(
+                    text = stringResource(R.string.choose_model_description, deviceRamGb),
+                    modifier = Modifier
+                        .fillMaxWidth()
+                        .padding(bottom = 4.dp)
+                )
+            }
             if (gemma4Models.isNotEmpty()) {
-                ModelGroupHeader(stringResource(R.string.models_group_gemma4))
-                gemma4Models.forEach { model ->
+                item { ModelGroupHeader(stringResource(R.string.models_group_gemma4)) }
+                items(gemma4Models) { model ->
                     ModelCard(model, model in downloadedModels, model == selectedModel,
                         model.minRamGb > deviceRamGb, deviceRamGb, onSelectModel, onDownloadModel)
                 }
             }
-
             if (loginModels.isNotEmpty()) {
-                ModelGroupHeader(stringResource(R.string.models_group_login))
-                loginModels.forEach { model ->
+                item { ModelGroupHeader(stringResource(R.string.models_group_login)) }
+                items(loginModels) { model ->
                     ModelCard(model, model in downloadedModels, model == selectedModel,
                         model.minRamGb > deviceRamGb, deviceRamGb, onSelectModel, onDownloadModel)
                 }
@@ -911,7 +822,28 @@ private fun ModelCard(
     onSelectModel: (AiModel) -> Unit,
     onDownloadModel: (AiModel) -> Unit
 ) {
-    Surface(
+    val haptic = LocalHapticFeedback.current
+    val interactionSource = remember { MutableInteractionSource() }
+    val isPressed by interactionSource.collectIsPressedAsState()
+    // Press feedback mirroring the calculator buttons: a subtle spring scale + haptic.
+    LaunchedEffect(isPressed) {
+        if (isPressed) haptic.performHapticFeedback(HapticFeedbackType.TextHandleMove)
+    }
+    val scale by animateFloatAsState(
+        targetValue = if (isPressed) 0.97f else 1f,
+        animationSpec = spring(dampingRatio = Spring.DampingRatioMediumBouncy, stiffness = Spring.StiffnessMedium),
+        label = "modelCardScale"
+    )
+    val containerColor by animateColorAsState(
+        targetValue = when {
+            tooLarge -> MaterialTheme.colorScheme.errorContainer.copy(alpha = 0.3f)
+            isSelected -> MaterialTheme.colorScheme.secondaryContainer
+            else -> MaterialTheme.colorScheme.surfaceContainerHigh
+        },
+        label = "modelCardColor"
+    )
+
+    OutlinedCard(
         onClick = {
             when {
                 isDownloaded -> onSelectModel(model)
@@ -919,21 +851,16 @@ private fun ModelCard(
                 else -> onDownloadModel(model)
             }
         },
+        interactionSource = interactionSource,
         modifier = Modifier
             .fillMaxWidth()
-            .then(
-                if (isSelected) Modifier.border(
-                    2.dp,
-                    MaterialTheme.colorScheme.primary,
-                    RoundedCornerShape(12.dp)
-                ) else Modifier
-            ),
-        shape = RoundedCornerShape(12.dp),
-        color = if (tooLarge)
-            MaterialTheme.colorScheme.errorContainer.copy(alpha = 0.3f)
+            .graphicsLayer { scaleX = scale; scaleY = scale },
+        shape = RoundedCornerShape(16.dp),
+        colors = CardDefaults.outlinedCardColors(containerColor = containerColor),
+        border = if (isSelected)
+            BorderStroke(2.dp, MaterialTheme.colorScheme.primary)
         else
-            MaterialTheme.colorScheme.surfaceVariant,
-        tonalElevation = 1.dp
+            CardDefaults.outlinedCardBorder()
     ) {
         Row(
             modifier = Modifier
@@ -941,10 +868,10 @@ private fun ModelCard(
                 .fillMaxWidth(),
             verticalAlignment = Alignment.CenterVertically
         ) {
-            Column(modifier = Modifier.weight(1f)) {
+            Column(modifier = Modifier.weight(1f).animateContentSize()) {
                 Text(
                     text = model.displayName,
-                    style = MaterialTheme.typography.titleSmall,
+                    style = MaterialTheme.typography.titleMedium,
                     fontWeight = FontWeight.Bold
                 )
                 Text(
@@ -953,7 +880,7 @@ private fun ModelCard(
                     color = MaterialTheme.colorScheme.onSurfaceVariant
                 )
                 Text(
-                    text = "${model.totalSizeDisplay} | ${model.minRamGb} GB+ RAM",
+                    text = "${model.totalSizeDisplay} · ${model.minRamGb} GB+ RAM",
                     style = MaterialTheme.typography.bodySmall,
                     color = MaterialTheme.colorScheme.onSurfaceVariant
                 )
@@ -966,6 +893,7 @@ private fun ModelCard(
                     )
                 }
             }
+            Spacer(modifier = Modifier.width(8.dp))
             if (isDownloaded) {
                 Icon(
                     imageVector = Icons.Default.CheckCircle,
@@ -995,36 +923,19 @@ private fun MobileDataWarningContent(
     onCancel: () -> Unit,
     onDismiss: () -> Unit
 ) {
-    Box(modifier = Modifier.fillMaxSize().navigationBarsPadding()) {
-        CloseButton(
-            onDismiss = onDismiss,
-            modifier = Modifier
-                .align(Alignment.TopStart)
-                .statusBarsPadding()
-                .padding(8.dp)
-        )
+    AiStateScaffold(onDismiss = onDismiss) {
         Column(
             modifier = Modifier
                 .align(Alignment.Center)
                 .padding(32.dp),
             horizontalAlignment = Alignment.CenterHorizontally,
-            verticalArrangement = Arrangement.spacedBy(16.dp)
+            verticalArrangement = Arrangement.spacedBy(20.dp)
         ) {
-            Icon(
-                imageVector = Icons.Default.ErrorOutline,
-                contentDescription = null,
-                modifier = Modifier.size(48.dp),
+            AiHero(
+                title = stringResource(R.string.mobile_data_title),
+                subtitle = stringResource(R.string.mobile_data_description, model.totalSizeDisplay),
+                icon = Icons.Default.ErrorOutline,
                 tint = MaterialTheme.colorScheme.error
-            )
-            Text(
-                text = stringResource(R.string.mobile_data_title),
-                style = MaterialTheme.typography.titleMedium
-            )
-            Text(
-                text = stringResource(R.string.mobile_data_description, model.totalSizeDisplay),
-                style = MaterialTheme.typography.bodyMedium,
-                color = MaterialTheme.colorScheme.onSurfaceVariant,
-                textAlign = TextAlign.Center
             )
             Row(horizontalArrangement = Arrangement.spacedBy(16.dp)) {
                 OutlinedButton(onClick = onCancel) {
@@ -1043,14 +954,7 @@ private fun FirstTimeWarningContent(
     onContinue: () -> Unit,
     onDismiss: () -> Unit
 ) {
-    Box(modifier = Modifier.fillMaxSize().navigationBarsPadding()) {
-        CloseButton(
-            onDismiss = onDismiss,
-            modifier = Modifier
-                .align(Alignment.TopStart)
-                .statusBarsPadding()
-                .padding(8.dp)
-        )
+    AiStateScaffold(onDismiss = onDismiss) {
         Column(
             modifier = Modifier
                 .align(Alignment.Center)
@@ -1058,22 +962,10 @@ private fun FirstTimeWarningContent(
             horizontalAlignment = Alignment.CenterHorizontally,
             verticalArrangement = Arrangement.spacedBy(20.dp)
         ) {
-            Icon(
-                imageVector = Icons.Default.Psychology,
-                contentDescription = null,
-                modifier = Modifier.size(56.dp),
-                tint = MaterialTheme.colorScheme.primary
-            )
-            Text(
-                text = stringResource(R.string.ai_feature_title),
-                style = MaterialTheme.typography.titleLarge,
-                textAlign = TextAlign.Center
-            )
-            Text(
-                text = stringResource(R.string.ai_feature_description),
-                style = MaterialTheme.typography.bodyMedium,
-                color = MaterialTheme.colorScheme.onSurfaceVariant,
-                textAlign = TextAlign.Center
+            AiHero(
+                title = stringResource(R.string.ai_feature_title),
+                subtitle = stringResource(R.string.ai_feature_description),
+                icon = Icons.Default.Psychology
             )
             Button(onClick = onContinue) {
                 Text(stringResource(R.string.ai_feature_continue))
@@ -1092,37 +984,20 @@ private fun AuthErrorContent(
 ) {
     val context = LocalContext.current
 
-    Box(modifier = Modifier.fillMaxSize().navigationBarsPadding()) {
-        CloseButton(
-            onDismiss = onDismiss,
-            modifier = Modifier
-                .align(Alignment.TopStart)
-                .statusBarsPadding()
-                .padding(8.dp)
-        )
+    AiStateScaffold(onDismiss = onDismiss) {
         Column(
             modifier = Modifier
                 .align(Alignment.Center)
                 .padding(32.dp),
             horizontalAlignment = Alignment.CenterHorizontally,
-            verticalArrangement = Arrangement.spacedBy(16.dp)
+            verticalArrangement = Arrangement.spacedBy(20.dp)
         ) {
-            Icon(
-                imageVector = Icons.Default.ErrorOutline,
-                contentDescription = null,
-                modifier = Modifier.size(48.dp),
-                tint = MaterialTheme.colorScheme.error
-            )
-
             if (httpCode == 403) {
-                Text(
-                    text = stringResource(R.string.license_required_title),
-                    style = MaterialTheme.typography.titleMedium
-                )
-                Text(
-                    text = stringResource(R.string.license_required_description, model.displayName),
-                    style = MaterialTheme.typography.bodyMedium,
-                    textAlign = TextAlign.Center
+                AiHero(
+                    title = stringResource(R.string.license_required_title),
+                    subtitle = stringResource(R.string.license_required_description, model.displayName),
+                    icon = Icons.Default.ErrorOutline,
+                    tint = MaterialTheme.colorScheme.error
                 )
                 Button(onClick = {
                     context.startActivity(Intent(Intent.ACTION_VIEW, Uri.parse(model.licenseUrl)))
@@ -1130,14 +1005,11 @@ private fun AuthErrorContent(
                     Text(stringResource(R.string.accept_license))
                 }
             } else {
-                Text(
-                    text = stringResource(R.string.token_invalid_title),
-                    style = MaterialTheme.typography.titleMedium
-                )
-                Text(
-                    text = stringResource(R.string.token_invalid_description),
-                    style = MaterialTheme.typography.bodyMedium,
-                    textAlign = TextAlign.Center
+                AiHero(
+                    title = stringResource(R.string.token_invalid_title),
+                    subtitle = stringResource(R.string.token_invalid_description),
+                    icon = Icons.Default.ErrorOutline,
+                    tint = MaterialTheme.colorScheme.error
                 )
                 Button(onClick = onReauth) {
                     Text(stringResource(R.string.sign_in_again))
@@ -1157,36 +1029,18 @@ private fun SignInContent(
     onSignIn: () -> Unit,
     onDismiss: () -> Unit
 ) {
-    Box(modifier = Modifier.fillMaxSize().navigationBarsPadding()) {
-        CloseButton(
-            onDismiss = onDismiss,
-            modifier = Modifier
-                .align(Alignment.TopStart)
-                .statusBarsPadding()
-                .padding(8.dp)
-        )
+    AiStateScaffold(onDismiss = onDismiss) {
         Column(
             modifier = Modifier
                 .align(Alignment.Center)
                 .padding(32.dp),
             horizontalAlignment = Alignment.CenterHorizontally,
-            verticalArrangement = Arrangement.spacedBy(16.dp)
+            verticalArrangement = Arrangement.spacedBy(20.dp)
         ) {
-            Icon(
-                imageVector = Icons.AutoMirrored.Filled.Login,
-                contentDescription = null,
-                modifier = Modifier.size(48.dp),
-                tint = MaterialTheme.colorScheme.primary
-            )
-            Text(
-                text = stringResource(R.string.hf_token_title),
-                style = MaterialTheme.typography.titleMedium
-            )
-            Text(
-                text = stringResource(R.string.hf_token_description, model.displayName),
-                style = MaterialTheme.typography.bodyMedium,
-                color = MaterialTheme.colorScheme.onSurfaceVariant,
-                textAlign = TextAlign.Center
+            AiHero(
+                title = stringResource(R.string.hf_token_title),
+                subtitle = stringResource(R.string.hf_token_description, model.displayName),
+                icon = Icons.AutoMirrored.Filled.Login
             )
             Button(onClick = onSignIn) {
                 Text(stringResource(R.string.sign_in_huggingface))
@@ -1205,14 +1059,7 @@ private fun DownloadingContent(
     onCancel: () -> Unit,
     onDismiss: () -> Unit
 ) {
-    Box(modifier = Modifier.fillMaxSize().navigationBarsPadding()) {
-        CloseButton(
-            onDismiss = onDismiss,
-            modifier = Modifier
-                .align(Alignment.TopStart)
-                .statusBarsPadding()
-                .padding(8.dp)
-        )
+    AiStateScaffold(onDismiss = onDismiss) {
         Column(
             modifier = Modifier
                 .align(Alignment.Center)
@@ -1220,15 +1067,10 @@ private fun DownloadingContent(
             horizontalAlignment = Alignment.CenterHorizontally,
             verticalArrangement = Arrangement.spacedBy(16.dp)
         ) {
-            Icon(
-                imageVector = Icons.Default.CloudDownload,
-                contentDescription = null,
-                modifier = Modifier.size(48.dp),
-                tint = MaterialTheme.colorScheme.primary
-            )
-            Text(
-                text = stringResource(R.string.downloading_model),
-                style = MaterialTheme.typography.titleMedium
+            AiHero(
+                title = stringResource(R.string.downloading_model),
+                icon = Icons.Default.CloudDownload,
+                pulsing = true
             )
             Text(
                 text = stringResource(R.string.download_file_progress, fileIndex + 1, fileCount),
@@ -1241,33 +1083,24 @@ private fun DownloadingContent(
                 fontWeight = FontWeight.Bold,
                 textAlign = TextAlign.Center
             )
-            if (totalBytes > 0) {
-                val progress = downloadedBytes.toFloat() / totalBytes.toFloat()
-                LinearProgressIndicator(
-                    progress = { progress },
-                    modifier = Modifier
-                        .fillMaxWidth()
-                        .padding(horizontal = 16.dp),
-                )
-                Text(
-                    text = "${formatBytes(downloadedBytes)} / ${formatBytes(totalBytes)} (${(progress * 100).toInt()}%)",
-                    style = MaterialTheme.typography.bodySmall,
-                    color = MaterialTheme.colorScheme.onSurfaceVariant
-                )
-            } else {
-                LinearProgressIndicator(
-                    modifier = Modifier
-                        .fillMaxWidth()
-                        .padding(horizontal = 16.dp),
-                )
-                if (downloadedBytes > 0) {
-                    Text(
-                        text = formatBytes(downloadedBytes),
-                        style = MaterialTheme.typography.bodySmall,
-                        color = MaterialTheme.colorScheme.onSurfaceVariant
-                    )
-                }
-            }
+            val progress = if (totalBytes > 0) downloadedBytes.toFloat() / totalBytes.toFloat() else null
+            AiDownloadBar(
+                progress = progress,
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .padding(horizontal = 16.dp)
+            )
+            Text(
+                text = when {
+                    progress != null ->
+                        "${formatBytes(downloadedBytes)} / ${formatBytes(totalBytes)} (${(progress * 100).toInt()}%)"
+                    downloadedBytes > 0 -> formatBytes(downloadedBytes)
+                    else -> ""
+                },
+                style = MaterialTheme.typography.bodySmall,
+                color = MaterialTheme.colorScheme.onSurfaceVariant,
+                modifier = Modifier.animateContentSize()
+            )
             Text(
                 text = stringResource(R.string.download_warning),
                 style = MaterialTheme.typography.bodySmall,

--- a/app/src/main/java/com/vagujhelyigergely/calculatorm3/camera/ScanComponents.kt
+++ b/app/src/main/java/com/vagujhelyigergely/calculatorm3/camera/ScanComponents.kt
@@ -1,0 +1,320 @@
+@file:OptIn(ExperimentalSharedTransitionApi::class, ExperimentalMaterial3ExpressiveApi::class)
+
+package com.vagujhelyigergely.calculatorm3.camera
+
+import androidx.compose.animation.AnimatedVisibilityScope
+import androidx.compose.animation.ExperimentalSharedTransitionApi
+import androidx.compose.animation.SharedTransitionScope
+import androidx.compose.animation.core.EaseInOutSine
+import androidx.compose.animation.core.LinearEasing
+import androidx.compose.animation.core.RepeatMode
+import androidx.compose.animation.core.animateFloat
+import androidx.compose.animation.core.animateFloatAsState
+import androidx.compose.animation.core.infiniteRepeatable
+import androidx.compose.animation.core.rememberInfiniteTransition
+import androidx.compose.animation.core.tween
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.BoxScope
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.navigationBarsPadding
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.layout.statusBarsPadding
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.Close
+import androidx.compose.material3.CardColors
+import androidx.compose.material3.CardDefaults
+import androidx.compose.material3.ElevatedCard
+import androidx.compose.material3.ExperimentalMaterial3ExpressiveApi
+import androidx.compose.material3.Icon
+import androidx.compose.material3.IconButton
+import androidx.compose.material3.LinearWavyProgressIndicator
+import androidx.compose.material3.LoadingIndicator
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.compositionLocalOf
+import androidx.compose.runtime.getValue
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
+import androidx.compose.ui.draw.drawBehind
+import androidx.compose.ui.geometry.Offset
+import androidx.compose.ui.graphics.Brush
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.graphics.Shape
+import androidx.compose.ui.graphics.graphicsLayer
+import androidx.compose.ui.graphics.vector.ImageVector
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.text.style.TextAlign
+import androidx.compose.ui.unit.dp
+import androidx.compose.ui.zIndex
+import com.vagujhelyigergely.calculatorm3.R
+
+// ---------------------------------------------------------------------------
+// Shared-element plumbing
+//
+// The scan UI is a state machine, not a NavHost, so there's no automatic shared
+// element scope. We expose the SharedTransitionScope (from the SharedTransitionLayout
+// that wraps the AnimatedContent in CameraScanScreen) and the per-content
+// AnimatedVisibilityScope through CompositionLocals, so the building blocks below can
+// opt elements into shared-bounds morphs without every state composable having to
+// thread the two scopes through its signature.
+//
+// When the locals are absent (e.g. an @Preview that renders a single state with no
+// SharedTransitionLayout around it) the shared modifiers degrade to no-ops, so the
+// same composables stay previewable.
+// ---------------------------------------------------------------------------
+
+internal val LocalSharedTransitionScope = compositionLocalOf<SharedTransitionScope?> { null }
+internal val LocalAiVisibilityScope = compositionLocalOf<AnimatedVisibilityScope?> { null }
+
+/** Morphing shared bounds keyed by [key] — used for elements whose content changes between states. */
+@Composable
+internal fun Modifier.aiSharedBounds(key: String): Modifier {
+    val shared = LocalSharedTransitionScope.current
+    val visibility = LocalAiVisibilityScope.current
+    return if (shared != null && visibility != null) {
+        with(shared) { sharedBounds(rememberSharedContentState(key), visibility) }
+    } else this
+}
+
+/** Shared element keyed by [key] — used for identical content that should stay anchored across states. */
+@Composable
+internal fun Modifier.aiSharedElement(key: String): Modifier {
+    val shared = LocalSharedTransitionScope.current
+    val visibility = LocalAiVisibilityScope.current
+    return if (shared != null && visibility != null) {
+        with(shared) { sharedElement(rememberSharedContentState(key), visibility) }
+    } else this
+}
+
+// ---------------------------------------------------------------------------
+// Layout scaffolding shared by every scan state
+// ---------------------------------------------------------------------------
+
+/** The close (X) button anchored top-start on every scan screen. */
+@Composable
+internal fun CloseButton(onDismiss: () -> Unit, modifier: Modifier = Modifier) {
+    IconButton(onClick = onDismiss, modifier = modifier) {
+        Icon(
+            imageVector = Icons.Default.Close,
+            contentDescription = stringResource(R.string.close),
+            tint = MaterialTheme.colorScheme.onSurface
+        )
+    }
+}
+
+/**
+ * Common full-screen container: navigation-bar inset, a shared-element close button
+ * top-start, and a [content] slot (BoxScope, so callers can center their column).
+ * Replaces the Box + CloseButton boilerplate every state used to repeat.
+ */
+@Composable
+internal fun AiStateScaffold(
+    onDismiss: () -> Unit,
+    modifier: Modifier = Modifier,
+    showClose: Boolean = true,
+    content: @Composable BoxScope.() -> Unit
+) {
+    Box(modifier = modifier.fillMaxSize().navigationBarsPadding()) {
+        content()
+        if (showClose) {
+            CloseButton(
+                onDismiss = onDismiss,
+                modifier = Modifier
+                    .align(Alignment.TopStart)
+                    .statusBarsPadding()
+                    .padding(8.dp)
+                    .zIndex(1f)
+                    .aiSharedElement("close")
+            )
+        }
+    }
+}
+
+/**
+ * Centered hero header used by most states: a morphing icon-or-loader slot (shared
+ * bounds keyed "hero-icon") above a shared title and an optional hint. Because the
+ * slot and title keep stable keys across states, switching states animates the hero
+ * smoothly instead of cutting.
+ */
+@Composable
+internal fun AiHero(
+    title: String,
+    modifier: Modifier = Modifier,
+    icon: ImageVector? = null,
+    subtitle: String? = null,
+    loading: Boolean = false,
+    pulsing: Boolean = false,
+    tint: Color = MaterialTheme.colorScheme.primary,
+    titleColor: Color = Color.Unspecified,
+) {
+    Column(
+        modifier = modifier,
+        horizontalAlignment = Alignment.CenterHorizontally,
+        verticalArrangement = Arrangement.spacedBy(16.dp)
+    ) {
+        Box(
+            modifier = Modifier.aiSharedBounds("hero-icon"),
+            contentAlignment = Alignment.Center
+        ) {
+            when {
+                loading -> AiLoader()
+                icon != null -> {
+                    val pulse = if (pulsing) rememberPulseScale() else 1f
+                    Icon(
+                        imageVector = icon,
+                        contentDescription = null,
+                        tint = tint,
+                        modifier = Modifier
+                            .size(56.dp)
+                            .graphicsLayer { scaleX = pulse; scaleY = pulse }
+                    )
+                }
+            }
+        }
+        Text(
+            text = title,
+            style = MaterialTheme.typography.titleLarge,
+            textAlign = TextAlign.Center,
+            color = titleColor,
+            modifier = Modifier.aiSharedBounds("hero-title")
+        )
+        if (subtitle != null) AiHint(subtitle)
+    }
+}
+
+/** Standard centered secondary text; animates its size so phase/text swaps grow smoothly. */
+@Composable
+internal fun AiHint(text: String, modifier: Modifier = Modifier) {
+    Text(
+        text = text,
+        style = MaterialTheme.typography.bodyMedium,
+        color = MaterialTheme.colorScheme.onSurfaceVariant,
+        textAlign = TextAlign.Center,
+        modifier = modifier
+    )
+}
+
+/** ElevatedCard wrapper carrying the app's rounded-corner + tonal-surface convention. */
+@Composable
+internal fun AiCard(
+    modifier: Modifier = Modifier,
+    colors: CardColors = CardDefaults.elevatedCardColors(),
+    content: @Composable () -> Unit
+) {
+    ElevatedCard(
+        modifier = modifier,
+        shape = RoundedCornerShape(16.dp),
+        colors = colors,
+        elevation = CardDefaults.elevatedCardElevation(defaultElevation = 2.dp)
+    ) {
+        content()
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Loaders
+// ---------------------------------------------------------------------------
+
+/** The M3-Expressive morphing loading indicator, sized for the hero slot. */
+@Composable
+internal fun AiLoader(modifier: Modifier = Modifier) {
+    LoadingIndicator(modifier = modifier.size(52.dp))
+}
+
+/**
+ * Download progress bar. [progress] in 0..1 draws a determinate wavy bar (animated so
+ * it eases toward each new value); null draws the indeterminate wavy bar (used while
+ * waiting for the network before any bytes arrive).
+ */
+@Composable
+internal fun AiDownloadBar(progress: Float?, modifier: Modifier = Modifier) {
+    if (progress == null) {
+        LinearWavyProgressIndicator(modifier = modifier)
+    } else {
+        val animated by animateFloatAsState(
+            targetValue = progress.coerceIn(0f, 1f),
+            animationSpec = tween(400),
+            label = "downloadProgress"
+        )
+        LinearWavyProgressIndicator(progress = { animated }, modifier = modifier)
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Shimmer skeletons (for first-paint loading, e.g. the model list)
+// ---------------------------------------------------------------------------
+
+/** A sweeping highlight gradient that animates across the element, clipped to [shape]. */
+@Composable
+internal fun Modifier.shimmer(shape: Shape = RoundedCornerShape(16.dp)): Modifier {
+    val transition = rememberInfiniteTransition(label = "shimmer")
+    val x by transition.animateFloat(
+        initialValue = 0f,
+        targetValue = 1f,
+        animationSpec = infiniteRepeatable(animation = tween(1300, easing = LinearEasing)),
+        label = "shimmerX"
+    )
+    val base = MaterialTheme.colorScheme.surfaceVariant
+    val highlight = MaterialTheme.colorScheme.surfaceContainerHighest
+    return this
+        .clip(shape)
+        .drawBehind {
+            val w = size.width
+            val offset = x * 2f * w - w
+            drawRect(
+                Brush.linearGradient(
+                    colors = listOf(base, highlight, base),
+                    start = Offset(offset, 0f),
+                    end = Offset(offset + w, 0f)
+                )
+            )
+        }
+}
+
+/**
+ * A few shimmering placeholder lines, used as a skeleton "answer" while the vision
+ * model prefills the image (the genuinely slow, token-less phase) — it then morphs
+ * into the streaming text as tokens arrive.
+ */
+@Composable
+internal fun ShimmerLines(modifier: Modifier = Modifier, lines: Int = 3) {
+    Column(modifier = modifier, verticalArrangement = Arrangement.spacedBy(12.dp)) {
+        repeat(lines) { index ->
+            val isLast = index == lines - 1
+            Box(
+                modifier = Modifier
+                    .fillMaxWidth(if (isLast) 0.55f else 1f)
+                    .height(14.dp)
+                    .shimmer(RoundedCornerShape(7.dp))
+            )
+        }
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Small helpers
+// ---------------------------------------------------------------------------
+
+/** A gentle 1.0→1.12 breathing scale, for icons of in-progress states. */
+@Composable
+internal fun rememberPulseScale(): Float {
+    val transition = rememberInfiniteTransition(label = "pulse")
+    val scale by transition.animateFloat(
+        initialValue = 1f,
+        targetValue = 1.12f,
+        animationSpec = infiniteRepeatable(
+            animation = tween(900, easing = EaseInOutSine),
+            repeatMode = RepeatMode.Reverse
+        ),
+        label = "pulseScale"
+    )
+    return scale
+}


### PR DESCRIPTION
Closes #49.

Redesigns the on-device AI scan surfaces to feel premium and follow Material 3, with fluid state transitions and polished loading states. **No behavior changes** — ViewModel, `ScanUiState`, callbacks, downloads, OAuth, markdown/LaTeX, and EXIF are untouched; this is presentational + animation only.

## Changes
- **Fluid state transitions:** the scan `when(uiState)` is wrapped in `SharedTransitionLayout` + `AnimatedContent` — states cross-fade/scale, and the hero icon/title, close button, and answer card morph across states (the streaming "Solving…" card morphs straight into the Success result). A coarse `screenKey()` keeps streaming/download ticks from replaying the transition.
- **New `camera/ScanComponents.kt`** — reusable M3 building blocks: `AiStateScaffold`, `AiHero`, `AiCard` (ElevatedCard), the expressive loaders (`LoadingIndicator` / `LinearWavyProgressIndicator`), and `Modifier.shimmer()` + skeleton. Shared-element modifiers no-op outside a `SharedTransitionLayout`, so the blocks stay previewable.
- **Model picker** → `Scaffold` + collapsing `LargeTopAppBar` + `LazyColumn` of `OutlinedCard`s with press haptics, spring scale, and animated selection / too-large colors (matching the calculator buttons).
- First-run `AlertDialog` gains the Psychology icon; debug `@Preview`s added.
- Net **−152 lines** in the main file (the scaffold/hero dedup removes more boilerplate than the polish adds).

## Dependencies — please note
- Compose BOM `2024.12.01 → 2025.10.01`, **material3 `1.3.1 → 1.5.0-alpha14`**. The M3-Expressive loaders ship only in material3 1.5.0-alpha; alpha14 is the last that stays on Compose 1.8/1.9, so `compileSdk`/AGP are unchanged. This is an **alpha** dependency — worth revisiting when 1.5.0 stabilizes.
- `lint { disable += "NullSafeMutableLiveData" }`: the bumped libraries trip AGP 8.7.3's bundled detector with an `IncompatibleClassChangeError` that aborts release `lintVital`. It's a tooling-version crash, not a code finding; the proper long-term fix is an AGP bump.

## Verification
- Debug + minified release builds green.
- On-device (6 GB device): calculator unchanged, redesigned first-run hero, dialog icon, and `LargeTopAppBar` model picker all render correctly in dynamic-color dark theme. Loader / streaming / download states are model-gated (not exercised on-device); covered by `@Preview`s and by compiling against the verified expressive-loader APIs.
