### PR TITLE
Fix AI-feature bugs found in code review

### DIFF
--- a/app/src/main/java/com/vagujhelyigergely/calculatorm3/CalculatorViewModel.kt
+++ b/app/src/main/java/com/vagujhelyigergely/calculatorm3/CalculatorViewModel.kt
@@ -391,32 +391,50 @@ class CalculatorViewModel(
     val displayExpression: String
         get() = formatForDisplay(expression)
 
+    // π as a plain decimal string, plus the implicit-multiplication / normalization patterns
+    // for [evaluate]. Compiled once (per ViewModel) instead of on every keystroke — evaluate()
+    // runs from updatePreview() on each input.
+    private val piPlain = PI.toPlainString()
+    private val rePctDigit = Regex("%(\\d)")
+    private val rePctPi = Regex("%π")
+    private val reDigitPi = Regex("(\\d)π")
+    private val rePiDigit = Regex("π(\\d)")
+    private val rePiBeforePi = Regex("π(?=π)")
+    private val reRParenPi = Regex("\\)π")
+    private val rePiLParen = Regex("π\\(")
+    private val reRParenDigit = Regex("\\)(\\d)")
+    private val reDigitLParen = Regex("(\\d)\\(")
+    private val reDigitSqrt = Regex("(\\d)√")
+    private val reFactDigit = Regex("!(\\d)")
+    private val reRParenSqrt = Regex("\\)√")
+    private val reFactSqrt = Regex("!√")
+    private val rePctSqrt = Regex("%√")
+
     private fun evaluate(expr: String): String {
         return try {
-            val piPlain = PI.toPlainString()
             val sanitized = expr
                 .replace("×", "*")
                 .replace("÷", "/")
                 .replace("−", "-")
                 // Implicit multiply after %: 50%3 → 50%*3, 50%π → 50%*π
-                .replace(Regex("%(\\d)"), "%*$1")
-                .replace(Regex("%π"), "%*π")
+                .replace(rePctDigit, "%*$1")
+                .replace(rePctPi, "%*π")
                 // Implicit multiplication around π
-                .replace(Regex("(\\d)π"), "$1*π")
-                .replace(Regex("π(\\d)"), "π*$1")
-                .replace(Regex("π(?=π)"), "π*")
-                .replace(Regex("\\)π"), ")*π")
-                .replace(Regex("π\\("), "π*(")
+                .replace(reDigitPi, "$1*π")
+                .replace(rePiDigit, "π*$1")
+                .replace(rePiBeforePi, "π*")
+                .replace(reRParenPi, ")*π")
+                .replace(rePiLParen, "π*(")
                 .replace("π", piPlain)
                 // Implicit multiplication between ) and digit, digit and (, digit and √, ! and digit
-                .replace(Regex("\\)(\\d)"), ")*$1")
-                .replace(Regex("(\\d)\\("), "$1*(")
-                .replace(Regex("(\\d)√"), "$1*√")
-                .replace(Regex("!(\\d)"), "!*$1")
+                .replace(reRParenDigit, ")*$1")
+                .replace(reDigitLParen, "$1*(")
+                .replace(reDigitSqrt, "$1*√")
+                .replace(reFactDigit, "!*$1")
                 // Implicit multiplication before √ from ), !, %
-                .replace(Regex("\\)√"), ")*√")
-                .replace(Regex("!√"), "!*√")
-                .replace(Regex("%√"), "%*√")
+                .replace(reRParenSqrt, ")*√")
+                .replace(reFactSqrt, "!*√")
+                .replace(rePctSqrt, "%*√")
 
             val result = evaluateExpression(sanitized)
 

--- a/app/src/main/java/com/vagujhelyigergely/calculatorm3/ai/LiteRTSolver.kt
+++ b/app/src/main/java/com/vagujhelyigergely/calculatorm3/ai/LiteRTSolver.kt
@@ -30,10 +30,6 @@ class LiteRTSolver : MathSolver {
     @Volatile private var currentModelPath: String? = null
     @Volatile private var backendLabel: String = "—"
 
-    /** TEMP debug: short reason the GPU backend failed to load (null on success). */
-    @Volatile override var lastGpuError: String? = null
-        private set
-
     override val isModelLoaded: Boolean get() = engine != null
     override val activeBackend: String get() = backendLabel
 
@@ -50,10 +46,8 @@ class LiteRTSolver : MathSolver {
         try {
             engine = buildEngine(modelPath, Backend.GPU(), Backend.GPU())
             backendLabel = "GPU"
-            lastGpuError = null
             return
         } catch (e: Exception) {
-            lastGpuError = "GPU: " + (e.message ?: e.toString()).replace('\n', ' ').take(200)
             Log.w(TAG, "GPU backend failed, falling back to CPU", e)
         }
         engine = buildEngine(modelPath, Backend.CPU(), Backend.CPU())

--- a/app/src/main/java/com/vagujhelyigergely/calculatorm3/ai/MathSolver.kt
+++ b/app/src/main/java/com/vagujhelyigergely/calculatorm3/ai/MathSolver.kt
@@ -13,9 +13,6 @@ interface MathSolver {
     /** Which compute backend the loaded model is running on ("GPU", "CPU", or "—"). */
     val activeBackend: String
 
-    /** TEMP debug: short reason the GPU backend failed to load, or null. */
-    val lastGpuError: String? get() = null
-
     suspend fun loadModel(modelPath: String)
     suspend fun solveFromImageStreaming(
         imagePath: String,
@@ -41,25 +38,36 @@ object SolverPrompts {
     const val TOP_P = 0.95f
     const val TEMPERATURE = 1.0f
 
-    /** Extract the numerical answer from the LLM response.
-     *  Checks the last non-empty line first (where the model is prompted to put the answer),
-     *  then falls back to the last number in the full response. */
+    private val numberPattern = Regex("-?(\\d+\\.?\\d*|\\.\\d+)([eE][+-]?\\d+)?")
+    // English thousands separators ("1,234" -> "1234"): a comma between a digit and exactly
+    // three digits that aren't themselves followed by another digit.
+    private val thousandsSeparator = Regex("(?<=\\d),(?=\\d{3}(?:\\D|\$))")
+
+    /**
+     * Extract the numerical answer from the LLM response. The model is prompted to put only
+     * the number on the last line, so that case is trusted first; the remaining steps degrade
+     * gracefully for messier output (an `= 42` tail, an aside like `17 (12+5)`, `1,234`)
+     * instead of blindly grabbing the last trailing token.
+     */
     fun extractAnswer(raw: String): String {
-        val numberPattern = Regex("-?(\\d+\\.?\\d*|\\.\\d+)([eE][+-]?\\d+)?")
-        // Try the last non-empty line first (system prompt tells model to put answer there)
-        val lastLine = raw.trimEnd().lines().lastOrNull { it.isNotBlank() }?.trim() ?: ""
-        val lastLineMatch = numberPattern.find(lastLine)
-        if (lastLineMatch != null && lastLineMatch.value == lastLine) {
-            // Last line is purely a number — high confidence answer
-            return lastLineMatch.value
+        val cleaned = raw.replace(thousandsSeparator, "")
+        val lastLine = cleaned.trimEnd().lines().lastOrNull { it.isNotBlank() }?.trim() ?: ""
+
+        // 1) Last line is exactly a number (what the system prompt asks for) — highest confidence.
+        numberPattern.matchEntire(lastLine)?.let { return it.value }
+
+        // 2) The number right after the last '=' ("x = 42", "= 17 (i.e. 12+5)").
+        val afterEquals = lastLine.substringAfterLast('=', "")
+        if (afterEquals.isNotEmpty() && afterEquals.length < lastLine.length) {
+            numberPattern.find(afterEquals)?.let { return it.value }
         }
-        // Fall back to last number on the last line
+
+        // 3) A single number on the last line is unambiguous; with several, the stated result
+        //    usually leads and asides like "17 (12+5)" follow, so prefer the first.
         val lastLineNumbers = numberPattern.findAll(lastLine).toList()
-        if (lastLineNumbers.isNotEmpty()) {
-            return lastLineNumbers.last().value
-        }
-        // Final fallback: last number anywhere in the response
-        val allNumbers = numberPattern.findAll(raw).toList()
-        return allNumbers.lastOrNull()?.value ?: ""
+        if (lastLineNumbers.isNotEmpty()) return lastLineNumbers.first().value
+
+        // 4) Nothing on the last line — fall back to the last number anywhere.
+        return numberPattern.findAll(cleaned).lastOrNull()?.value ?: ""
     }
 }

--- a/app/src/main/java/com/vagujhelyigergely/calculatorm3/ai/ModelManager.kt
+++ b/app/src/main/java/com/vagujhelyigergely/calculatorm3/ai/ModelManager.kt
@@ -221,7 +221,13 @@ class ModelManager(private val context: Context) {
             connection.instanceFollowRedirects = true
             if (model.requiresAuth) {
                 val token = hfToken
-                    ?: throw Exception("HuggingFace sign-in is required for this model.")
+                    // DownloadAuthException (not a generic Exception) so the worker reports
+                    // ERROR_AUTH and the UI routes to the sign-in prompt, not a generic error.
+                    ?: throw DownloadAuthException(
+                        "HuggingFace sign-in is required for this model.",
+                        httpCode = 401,
+                        model = model
+                    )
                 connection.setRequestProperty("Authorization", "Bearer $token")
             }
             if (existingBytes > 0) {
@@ -248,7 +254,8 @@ class ModelManager(private val context: Context) {
                     return@withContext
                 }
                 tmpFile.delete()
-                throw Exception("Couldn't resume the download (HTTP 416); please retry.")
+                // IOException so WorkManager retries — the next run starts fresh (tmp deleted).
+                throw java.io.IOException("Couldn't resume the download (HTTP 416); please retry.")
             }
 
             val isResuming = code == HttpURLConnection.HTTP_PARTIAL && existingBytes > 0
@@ -291,7 +298,9 @@ class ModelManager(private val context: Context) {
             // keep the .tmp so the next run resumes via Range rather than marking a corrupt,
             // unloadable model as "installed".
             if (totalBytes > 0 && downloadedBytes < totalBytes) {
-                throw Exception("Download incomplete: received $downloadedBytes of $totalBytes bytes")
+                // IOException (not a generic Exception) so the worker treats this transient
+                // truncation as retryable (Result.retry()) and resumes via the kept .tmp.
+                throw java.io.IOException("Download incomplete: received $downloadedBytes of $totalBytes bytes")
             }
 
             if (!tmpFile.renameTo(destFile)) {

--- a/app/src/main/java/com/vagujhelyigergely/calculatorm3/ai/ModelManager.kt
+++ b/app/src/main/java/com/vagujhelyigergely/calculatorm3/ai/ModelManager.kt
@@ -180,7 +180,11 @@ class ModelManager(private val context: Context) {
 
     /** True if the device has enough RAM to run at least one model. */
     val canRunAnyModel: Boolean
-        get() = AiModel.entries.any { it.minRamGb <= deviceRamGb }
+        get() {
+            // Read deviceRamGb once — its getter does an ActivityManager binder call.
+            val ram = deviceRamGb
+            return AiModel.entries.any { it.minRamGb <= ram }
+        }
 
     /** True if the device is connected to Wi-Fi. */
     val isOnWifi: Boolean
@@ -217,7 +221,7 @@ class ModelManager(private val context: Context) {
             connection.instanceFollowRedirects = true
             if (model.requiresAuth) {
                 val token = hfToken
-                    ?: throw Exception("HuggingFace token required. Go to huggingface.co/settings/tokens to create one, then enter it in the app.")
+                    ?: throw Exception("HuggingFace sign-in is required for this model.")
                 connection.setRequestProperty("Authorization", "Bearer $token")
             }
             if (existingBytes > 0) {
@@ -226,6 +230,27 @@ class ModelManager(private val context: Context) {
             connection.connect()
 
             val code = connection.responseCode
+
+            // HTTP 416 (Range Not Satisfiable): the existing .tmp is already >= the full file —
+            // a prior run finished the bytes but died before renaming. Promote it if it's
+            // exactly the complete file; otherwise discard the unusable partial so the next run
+            // restarts cleanly instead of failing on 416 forever.
+            if (code == 416 && existingBytes > 0) {
+                val total = connection.getHeaderField("Content-Range")
+                    ?.substringAfterLast('/')?.toLongOrNull()
+                connection.disconnect()
+                if (total != null && existingBytes == total) {
+                    if (!tmpFile.renameTo(destFile)) {
+                        tmpFile.copyTo(destFile, overwrite = true)
+                        tmpFile.delete()
+                    }
+                    onProgress(existingBytes, existingBytes)
+                    return@withContext
+                }
+                tmpFile.delete()
+                throw Exception("Couldn't resume the download (HTTP 416); please retry.")
+            }
+
             val isResuming = code == HttpURLConnection.HTTP_PARTIAL && existingBytes > 0
             if (code != HttpURLConnection.HTTP_OK && !isResuming) {
                 throw when (code) {
@@ -259,6 +284,14 @@ class ModelManager(private val context: Context) {
                         onProgress(downloadedBytes, totalBytes)
                     }
                 }
+            }
+
+            // Don't promote a silently-truncated download: if the server announced a size
+            // (Content-Length present) but the stream ended early — a clean proxy/server EOF —
+            // keep the .tmp so the next run resumes via Range rather than marking a corrupt,
+            // unloadable model as "installed".
+            if (totalBytes > 0 && downloadedBytes < totalBytes) {
+                throw Exception("Download incomplete: received $downloadedBytes of $totalBytes bytes")
             }
 
             if (!tmpFile.renameTo(destFile)) {

--- a/app/src/main/java/com/vagujhelyigergely/calculatorm3/camera/ScanViewModel.kt
+++ b/app/src/main/java/com/vagujhelyigergely/calculatorm3/camera/ScanViewModel.kt
@@ -284,23 +284,37 @@ class ScanViewModel(
                 return@launch
             }
             val startTime = System.currentTimeMillis()
-            val backend = solver.activeBackend + (solver.lastGpuError?.let { "  ⚠ GPU: $it" } ?: "")
-            uiState = ScanUiState.Processing(startTimeMs = startTime, backend = backend)
-            // Apply EXIF rotation + downscale: a full-res photo can blow up the
-            // vision pipeline's memory, and the camera stores it sideways with an
-            // EXIF orientation tag the model would otherwise ignore.
-            val processPath = withContext(Dispatchers.IO) {
-                prepareImage(imagePath, MAX_IMAGE_EDGE) ?: imagePath
-            }
+            uiState = ScanUiState.Processing(startTimeMs = startTime, backend = solver.activeBackend)
+            var processPath: String? = null
             try {
+                // Apply EXIF rotation + downscale: a full-res photo can blow up the vision
+                // pipeline's memory, and the camera stores it sideways with an EXIF orientation
+                // tag the model would otherwise ignore.
+                processPath = withContext(Dispatchers.IO) { prepareImage(imagePath, MAX_IMAGE_EDGE) }
+                if (processPath == null) {
+                    // Preprocessing failed — do NOT fall back to the original full-resolution
+                    // photo, which can OOM the vision pipeline. Surface an error instead.
+                    uiState = ScanUiState.Error("Couldn't process that image. Please try another photo.")
+                    return@launch
+                }
                 var tokenCount = 0
                 var firstTokenMs = 0L
                 var lastTokenMs = 0L
                 var lastUiUpdateMs = 0L
+                var lastRawLen = 0
                 val result = solver.solveFromImageStreaming(processPath) { partialRaw ->
                     // Time decode at the source (inference dispatcher), independent of the UI:
                     // the first token marks end-of-prefill (TTFT); the rest is the decode window.
                     val now = System.currentTimeMillis()
+                    // The solver can silently reload GPU→CPU and replay inference with this same
+                    // callback, restarting the streamed text from empty. Detect that reset (the
+                    // cumulative output shrank) and restart our counters so the stats reflect the
+                    // attempt that actually produced the answer.
+                    if (partialRaw.length < lastRawLen) {
+                        tokenCount = 0
+                        firstTokenMs = 0L
+                    }
+                    lastRawLen = partialRaw.length
                     if (tokenCount == 0) firstTokenMs = now
                     tokenCount++
                     lastTokenMs = now
@@ -316,7 +330,7 @@ class ScanViewModel(
                                 partialRaw = partialRaw,
                                 startTimeMs = startTime,
                                 tokenCount = uiTokenCount,
-                                backend = backend,
+                                backend = solver.activeBackend,
                                 firstTokenMs = uiFirstTokenMs
                             )
                         }
@@ -329,7 +343,8 @@ class ScanViewModel(
                     (tokenCount - 1) / (decodeMs / 1000.0) else 0.0
                 uiState = result.fold(
                     onSuccess = {
-                        ScanUiState.Success(it.answer, it.raw, elapsed, tokenCount, backend, ttftMs, decodeTps)
+                        // Re-read the backend after inference — it may have fallen back GPU→CPU.
+                        ScanUiState.Success(it.answer, it.raw, elapsed, tokenCount, solver.activeBackend, ttftMs, decodeTps)
                     },
                     onFailure = {
                         val raw = (it as? RecognitionException)?.rawResponse
@@ -342,9 +357,14 @@ class ScanViewModel(
                 if (e is kotlinx.coroutines.CancellationException) throw e
                 uiState = ScanUiState.Error("Inference failed: ${e.message}")
             } finally {
+                // Free the engine as soon as inference is done: it must NOT stay resident while
+                // the system camera launches for the next scan (large models OOM-kill the app —
+                // the reason model loading is deferred to here). It reloads lazily on the next
+                // photo.
+                releaseAll()
                 // Clean up captured photos
                 try { java.io.File(imagePath).delete() } catch (_: Exception) {}
-                if (processPath != imagePath) {
+                if (processPath != null && processPath != imagePath) {
                     try { java.io.File(processPath).delete() } catch (_: Exception) {}
                 }
             }

--- a/app/src/test/java/com/vagujhelyigergely/calculatorm3/ai/SolverPromptsTest.kt
+++ b/app/src/test/java/com/vagujhelyigergely/calculatorm3/ai/SolverPromptsTest.kt
@@ -109,4 +109,28 @@ class SolverPromptsTest {
     fun `scientific notation with plus`() {
         assertEquals("2.5e+8", SolverPrompts.extractAnswer("2.5e+8"))
     }
+
+    // ── Hardened fallbacks (avoid confidently-wrong trailing tokens) ──
+
+    @Test
+    fun `strips thousands separators on bare last line`() {
+        assertEquals("12345", SolverPrompts.extractAnswer("Result:\n12,345"))
+    }
+
+    @Test
+    fun `strips thousands separators in prose`() {
+        assertEquals("1234", SolverPrompts.extractAnswer("The total comes to 1,234"))
+    }
+
+    @Test
+    fun `number right after equals on a messy last line`() {
+        // Was '5' before (last number on the line); the result after '=' is the answer.
+        assertEquals("17", SolverPrompts.extractAnswer("So x = 17 (that is 12 + 5)"))
+    }
+
+    @Test
+    fun `prefers the stated result over a trailing aside`() {
+        // Was '5' before (last number); the leading number is the stated answer.
+        assertEquals("17", SolverPrompts.extractAnswer("The answer is 17 (i.e. 12+5)"))
+    }
 }


### PR DESCRIPTION
Fixes pre-existing bugs in the on-device AI scan / model-download / solve paths, surfaced by a high-effort code review. **Independent of the Material 3 UI PR (#60)** — touches only the AI logic files, so the two branches don't overlap.

## Correctness
- **OOM on the 2nd scan** — release the LiteRT engine as soon as inference finishes, so the multi-GB model isn't resident when the system camera launches for the next scan (it was only freed in `onCleared`). Reloads lazily on the next photo.
- **Full-res fallback** — when `prepareImage` fails, show an error instead of feeding the original full-resolution photo to the vision pipeline (`?: imagePath` defeated the downscale and could OOM).
- **Stale stats on GPU→CPU fallback** — re-read the backend after inference and reset the token/timing counters when the solver silently replays on CPU.
- **Truncated download promoted** — verify `downloaded == total` before renaming the `.tmp`, so a clean early EOF can't mark a corrupt model "installed".
- **HTTP 416 dead-end** — if a prior run finished the bytes but died before renaming, promote the complete `.tmp` (else discard + restart) instead of failing on the unsatisfiable Range request forever.
- **`extractAnswer` wrong tokens** — strip English thousands separators, prefer the number after the last `=`, and prefer the leading number on a messy line, so `1,234` / `17 (12+5)` / `x = 17 (...)` no longer yield a wrong trailing token. **+4 unit tests** (21 total, all green).

## Efficiency
- **Per-keystroke regex churn** — hoist the ~14 normalization regexes + `PI.toPlainString()` out of `evaluate()` (runs on every keystroke) so they compile once.
- **`canRunAnyModel`** — read `deviceRamGb` (an ActivityManager binder call) once, not once per model.

## Maintainability / UX
- Drop the "TEMP debug" `lastGpuError` plumbing that leaked a cryptic native error into the user-facing backend label.
- Fix the auth-error message that told users to "enter a token in the app" — only OAuth sign-in exists.

## Verification
`:app:compileDebugKotlin`, `:app:assembleDebug`, and `:app:testDebugUnitTest` all green (SolverPromptsTest 21/21; CalculatorViewModelTest confirms the regex hoist didn't change evaluation).
