### PR TITLE
Add Stop button to cancel an in-progress AI scan (#57)

### DIFF
--- a/app/src/main/java/com/vagujhelyigergely/calculatorm3/CalculatorScreen.kt
+++ b/app/src/main/java/com/vagujhelyigergely/calculatorm3/CalculatorScreen.kt
@@ -216,7 +216,12 @@ fun CalculatorScreen(
             onExpressionRecognized = { expr ->
                 viewModel.setExpressionFromScan(expr)
             },
-            onDismiss = { showCamera = false }
+            // Stop any in-flight inference before closing — the ViewModel is Activity-scoped, so
+            // without this the scan coroutine would keep generating in the background after dismiss.
+            onDismiss = {
+                scanViewModel.stopInference()
+                showCamera = false
+            }
         )
     }
 

--- a/app/src/main/java/com/vagujhelyigergely/calculatorm3/ai/LiteRTSolver.kt
+++ b/app/src/main/java/com/vagujhelyigergely/calculatorm3/ai/LiteRTSolver.kt
@@ -153,6 +153,17 @@ class LiteRTSolver : MathSolver {
         }
     }
 
+    override fun cancel() {
+        // Signal native generation to stop. Deliberately does NOT take [mutex]: the lock is held
+        // by the in-flight solveFromImageStreaming, and cancelProcess() is a thread-safe signal to
+        // the native side (not a state mutation), so read the @Volatile conversation directly.
+        try {
+            conversation?.cancelProcess()
+        } catch (e: Exception) {
+            Log.w(TAG, "cancelProcess() failed", e)
+        }
+    }
+
     private fun closeEngine() {
         try { conversation?.close() } catch (_: Exception) {}
         conversation = null

--- a/app/src/main/java/com/vagujhelyigergely/calculatorm3/ai/LiteRTSolver.kt
+++ b/app/src/main/java/com/vagujhelyigergely/calculatorm3/ai/LiteRTSolver.kt
@@ -10,6 +10,7 @@ import com.google.ai.edge.litertlm.Engine
 import com.google.ai.edge.litertlm.EngineConfig
 import com.google.ai.edge.litertlm.SamplerConfig
 import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.isActive
 import kotlinx.coroutines.sync.Mutex
 import kotlinx.coroutines.sync.withLock
 import kotlinx.coroutines.withContext
@@ -131,6 +132,11 @@ class LiteRTSolver : MathSolver {
                 // Never swallow cancellation — let the coroutine actually cancel
                 // instead of treating it as a failure and reloading on CPU.
                 if (e is kotlinx.coroutines.CancellationException) throw e
+                // A stop() interrupts native generation via cancelProcess(), which surfaces here as
+                // a native exception (not CancellationException) while the coroutine is being
+                // cancelled. Treat that as cancellation so we skip the expensive GPU→CPU reload+retry
+                // that would just be discarded at the next suspension point.
+                if (!isActive) throw kotlinx.coroutines.CancellationException("Inference cancelled", e)
                 Log.e(TAG, "LiteRT inference failed", e)
                 // If GPU was active, reload on CPU and retry once — some devices
                 // initialize the GPU backend fine but fault during inference.

--- a/app/src/main/java/com/vagujhelyigergely/calculatorm3/ai/MathSolver.kt
+++ b/app/src/main/java/com/vagujhelyigergely/calculatorm3/ai/MathSolver.kt
@@ -18,6 +18,15 @@ interface MathSolver {
         imagePath: String,
         onToken: suspend (partialRaw: String) -> Unit
     ): Result<RecognitionResult>
+
+    /**
+     * Interrupt an in-flight [solveFromImageStreaming] so native generation stops promptly.
+     * Must be safe to call WITHOUT holding the backend's internal lock — the running inference
+     * already holds it, and this is only a signal to the native side, not a state change.
+     * No-op by default for backends without a hard stop.
+     */
+    fun cancel() {}
+
     suspend fun release()
 }
 

--- a/app/src/main/java/com/vagujhelyigergely/calculatorm3/camera/CameraScanScreen.kt
+++ b/app/src/main/java/com/vagujhelyigergely/calculatorm3/camera/CameraScanScreen.kt
@@ -173,6 +173,7 @@ fun CameraScanScreen(
                                 tokenCount = state.tokenCount,
                                 backend = state.backend,
                                 firstTokenMs = state.firstTokenMs,
+                                onStop = { viewModel.stopInference() },
                                 onDismiss = onDismiss
                             )
                             is ScanUiState.Success -> SuccessContent(
@@ -344,6 +345,7 @@ private fun ProcessingContent(
     tokenCount: Int,
     backend: String,
     firstTokenMs: Long?,
+    onStop: () -> Unit,
     onDismiss: () -> Unit
 ) {
     val isGenerating = partialRaw.isNotEmpty()
@@ -395,6 +397,12 @@ private fun ProcessingContent(
             }
 
             PerfHud(startTimeMs = startTimeMs, tokenCount = tokenCount, backend = backend, firstTokenMs = firstTokenMs)
+
+            // Abort a slow or wrong generation and return to capture. Stop is prompt during token
+            // generation; during the initial image prefill it takes effect at the next boundary.
+            OutlinedButton(onClick = onStop) {
+                Text(stringResource(R.string.stop))
+            }
         }
     }
 }

--- a/app/src/main/java/com/vagujhelyigergely/calculatorm3/camera/ScanViewModel.kt
+++ b/app/src/main/java/com/vagujhelyigergely/calculatorm3/camera/ScanViewModel.kt
@@ -76,6 +76,7 @@ class ScanViewModel(
 
     private var loadedModelId: String? = null
     private var downloadObserver: Job? = null
+    private var inferenceJob: Job? = null
 
     fun initialize() {
         viewModelScope.launch {
@@ -120,6 +121,9 @@ class ScanViewModel(
             loadedModelId = model.id
             true
         } catch (e: Exception) {
+            // A stop during the load cancels this coroutine; let it propagate (the caller's
+            // finally releases the engine) instead of surfacing it as a load error.
+            if (e is kotlinx.coroutines.CancellationException) throw e
             loadedModelId = null
             uiState = ScanUiState.Error("Failed to load AI model: ${e.message}")
             false
@@ -276,17 +280,22 @@ class ScanViewModel(
 
     fun onPhotoCaptured(imagePath: String) {
         val model = modelManager.selectedModel
-        viewModelScope.launch {
-            // Load the model now that a photo exists (it wasn't resident while the
-            // camera app was open). Shows "Loading AI model…" then proceeds.
-            if (!ensureModelLoaded(model)) {
-                try { java.io.File(imagePath).delete() } catch (_: Exception) {}
-                return@launch
-            }
-            val startTime = System.currentTimeMillis()
-            uiState = ScanUiState.Processing(startTimeMs = startTime, backend = solver.activeBackend)
+        // Keep the Job so stopInference() can cancel just this inference. The ViewModel is
+        // Activity-scoped, so an un-cancelled job keeps generating in the background after dismiss.
+        inferenceJob = viewModelScope.launch {
+            // Streaming UI updates launch from this scope (not viewModelScope) so cancelling the
+            // inference also drops any in-flight token update, instead of it racing to overwrite
+            // the Capturing state stopInference() returns to.
+            val inferenceScope = this
             var processPath: String? = null
             try {
+                // Load the model now that a photo exists (it wasn't resident while the camera app
+                // was open). Shows "Loading AI model…" then proceeds. Kept inside the try so the
+                // finally releases the engine even if a stop cancels during the (uninterruptible)
+                // native load — otherwise the just-loaded model would stay resident.
+                if (!ensureModelLoaded(model)) return@launch
+                val startTime = System.currentTimeMillis()
+                uiState = ScanUiState.Processing(startTimeMs = startTime, backend = solver.activeBackend)
                 // Apply EXIF rotation + downscale: a full-res photo can blow up the vision
                 // pipeline's memory, and the camera stores it sideways with an EXIF orientation
                 // tag the model would otherwise ignore.
@@ -325,7 +334,7 @@ class ScanViewModel(
                         // Main thread; snapshot the mutable counters first to avoid a race.
                         val uiTokenCount = tokenCount
                         val uiFirstTokenMs = firstTokenMs.takeIf { it > 0L }
-                        viewModelScope.launch {
+                        inferenceScope.launch {
                             uiState = ScanUiState.Processing(
                                 partialRaw = partialRaw,
                                 startTimeMs = startTime,
@@ -368,6 +377,25 @@ class ScanViewModel(
                     try { java.io.File(processPath).delete() } catch (_: Exception) {}
                 }
             }
+        }
+    }
+
+    /**
+     * Abort an in-flight scan: signal the native side to stop generating, cancel the coroutine,
+     * and return to the capture screen with no error. The engine is released by onPhotoCaptured's
+     * finally (same as a normal scan), so the next photo reloads it lazily. Safe to call when
+     * nothing is running — used by both the Stop button and dialog dismiss.
+     */
+    fun stopInference() {
+        // Order matters: interrupt native generation first (it ignores coroutine cancellation),
+        // then cancel the coroutine so it unwinds cleanly via its CancellationException guards.
+        solver.cancel()
+        inferenceJob?.cancel()
+        inferenceJob = null
+        // Only snap back to capture if we were actually mid-scan; calling this from a dialog
+        // dismiss in another state (Success, Downloading, …) must not disturb that state.
+        if (uiState is ScanUiState.Processing || uiState is ScanUiState.ModelLoading) {
+            uiState = ScanUiState.Capturing
         }
     }
 

--- a/app/src/main/java/com/vagujhelyigergely/calculatorm3/camera/ScanViewModel.kt
+++ b/app/src/main/java/com/vagujhelyigergely/calculatorm3/camera/ScanViewModel.kt
@@ -280,8 +280,10 @@ class ScanViewModel(
 
     fun onPhotoCaptured(imagePath: String) {
         val model = modelManager.selectedModel
-        // Keep the Job so stopInference() can cancel just this inference. The ViewModel is
-        // Activity-scoped, so an un-cancelled job keeps generating in the background after dismiss.
+        // Cancel any still-running inference before starting a new one, so an overlapping call
+        // can't orphan the previous job (the ViewModel is Activity-scoped, so an un-cancelled job
+        // keeps generating in the background). Keep the new Job so stopInference() can cancel it.
+        inferenceJob?.cancel()
         inferenceJob = viewModelScope.launch {
             // Streaming UI updates launch from this scope (not viewModelScope) so cancelling the
             // inference also drops any in-flight token update, instead of it racing to overwrite

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -46,6 +46,7 @@
     <string name="use_expression">Use</string>
     <string name="use_answer">Use %1$s</string>
     <string name="retry">Retry</string>
+    <string name="stop">Stop</string>
     <string name="close">Close</string>
     <string name="recognition_error">Recognition failed</string>
     <string name="camera_permission_needed">Camera permission is needed to scan handwritten expressions</string>


### PR DESCRIPTION
Closes #57.

## What
Adds a **Stop** button so a user can abort a slow or clearly-wrong AI scan and go back to capturing, instead of waiting for it to finish or killing the app.

## Changes
- **Keep the inference `Job`** in `ScanViewModel`; new `stopInference()` signals the native side, cancels the coroutine, and returns to `Capturing` (no error shown).
- **`MathSolver.cancel()`** (default no-op); **`LiteRTSolver`** implements it as `Conversation.cancelProcess()`, called **without** the solver `Mutex` (held by the in-flight inference) by signalling the `@Volatile conversation` directly. Cancelling only the coroutine stops us *collecting* tokens; `cancelProcess()` interrupts native generation promptly — we do both.
- **Stop button** on the Processing screen, wired to `viewModel.stopInference()`.
- **Dialog dismiss** now calls `stopInference()` too, so closing mid-scan no longer leaks a background inference.
- `stop` string resource.

## Engine lifecycle on stop
On stop the engine is **released**, same as every scan since #61 (which frees the engine in `finally` to avoid OOM-killing the app while the system camera relaunches). The next photo reloads it lazily. This intentionally diverges from the issue's "reuse the already-loaded engine" wording — keeping a multi-GB model resident would reintroduce that OOM. The Stop action itself returns to capture instantly regardless.

## Hardening of the now-reachable cancel paths
- Streaming UI updates launch from the inference scope, so a token update queued just before Stop can't race back and overwrite `Capturing` with `Processing`.
- `ensureModelLoaded` moved inside the `try/finally` and now re-throws `CancellationException`, so a stop during the (uninterruptible) native model-load still releases the just-loaded engine and cleans up the cached image, rather than surfacing it as a load error.

## Notes
- Stop is shown only on the Processing screen. The native model-load can't be interrupted mid-call, so a Stop there would mislead; closing during load still aborts via the Close button → dismiss → `stopInference()`.

## Testing
- `./gradlew :app:compileDebugKotlin` — clean.
- `./gradlew :app:testDebugUnitTest` — pass.
- On-device runtime not exercised here (needs a device + downloaded model + camera).
