### PR TITLE
Cap scan image at 768px to match Gemma's native vision resolution

### DIFF
--- a/app/src/main/java/com/vagujhelyigergely/calculatorm3/camera/ScanViewModel.kt
+++ b/app/src/main/java/com/vagujhelyigergely/calculatorm3/camera/ScanViewModel.kt
@@ -511,8 +511,12 @@ class ScanViewModel(
     }
 
     companion object {
-        /** Longest edge (px) the captured photo is downscaled to before inference. */
-        private const val MAX_IMAGE_EDGE = 1024
+        /**
+         * Longest edge (px) the captured photo is downscaled to before inference. Capped at the
+         * model's native vision resolution (Gemma's encoder resizes any input to ≤768² anyway), so
+         * feeding more just added a redundant resample (photo→1024→768 instead of photo→768).
+         */
+        private const val MAX_IMAGE_EDGE = 768
 
         /** Min gap between streaming UI updates so per-token recomposition can't throttle decode. */
         private const val UI_UPDATE_THROTTLE_MS = 50L


### PR DESCRIPTION
Caps the scanned photo at 768px on its longest edge (was 1024).

Gemma's vision encoder downscales any input to <=768 on the longest edge internally, so feeding 1024px just added a redundant resample (photo->1024->768 instead of photo->768). 768 matches the model's native vision resolution: one clean downscale, marginally less preprocessing, and no change to decode speed or vision-token count.

Context: came out of a scan-performance pass. The LLM is already fast (scan decode ~= text-only speed; LLM prefill ~0.4s); the scan's perceptible wait is the vision encoder (TTFT), which this change does not affect. Kept 768 rather than going lower to preserve OCR accuracy on dense handwriting.