### PR TITLE
Sync docs with the unreleased 1.5.1 AI feature set

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,7 +37,7 @@
 - Scientific functions — square root, pi, power, factorial
 - Calculation history — persists across restarts
 - Expression cursor — tap to edit mid-expression
-- **AI Math Solver** — photograph handwritten math and get the answer (see below)
+- **AI Math Solver** — photograph handwritten math and solve it on-device (experimental; hidden until you unlock it — see below)
 - Dynamic color theming that matches your wallpaper (Android 12+)
 - Automatic light and dark mode
 - Adaptive layout — portrait, landscape, and foldable support
@@ -49,8 +49,10 @@
 
 Point your camera at a handwritten math expression and let an on-device AI model solve it for you. Everything runs locally — no data leaves your device.
 
+> **The AI Math Solver is hidden by default.** To reveal it, rapidly tap **AC** seven times — the same idea as Android's "tap Build number 7 times" to unlock developer options. A countdown toast guides the final taps, and once unlocked a camera icon appears in the top-left corner. The unlock is remembered across restarts.
+
 **How it works:**
-1. Tap the camera icon (top-left)
+1. Unlock the feature (see above), then tap the camera icon (top-left)
 2. Choose and download an AI model (one-time, ~2.6–4.9 GB; the download runs in a background service and survives the screen turning off). Gated models (Gemma 3n) first prompt a one-tap **Sign in with Hugging Face**
 3. Take a photo with your camera, or choose an existing photo from your gallery
 4. The model solves it entirely on-device — GPU-accelerated where supported — and streams its working, rendered with proper math formatting
@@ -63,12 +65,12 @@ All models are vision-capable and run on Google's [LiteRT-LM](https://github.com
 | Model | Download | Min RAM | Auth |
 |-------|----------|---------|------|
 | Gemma 4 E2B | ~2.6 GB | 6 GB | — |
-| Gemma 3n E2B | ~3.7 GB | 4 GB | HuggingFace sign-in |
+| Gemma 3n E2B | ~3.7 GB | 6 GB | HuggingFace sign-in |
 | Gemma 4 E4B | ~3.7 GB | 8 GB | — |
-| Gemma 3n E4B | ~4.9 GB | 6 GB | HuggingFace sign-in |
+| Gemma 3n E4B | ~4.9 GB | 8 GB | HuggingFace sign-in |
 
 **Requirements:**
-- Android device with 4+ GB RAM
+- Android device with 6+ GB RAM — the smallest model (Gemma 4 E2B) needs 6 GB and the larger E4B models need 8 GB; on devices with less, the solver shows a "not enough RAM" notice
 - A camera or gallery app (photos are taken via the system camera — no in-app camera permission required)
 - Internet for the one-time model download (Wi-Fi recommended)
 - Gemma 3n models require a free [HuggingFace](https://huggingface.co) account — you sign in once, in-app, and accept the model license; Gemma 4 models need no account ([setup](docs/huggingface-oauth-setup.md))

--- a/docs/privacy-policy.html
+++ b/docs/privacy-policy.html
@@ -13,7 +13,7 @@
 </head>
 <body>
     <h1>Privacy Policy</h1>
-    <p class="date">Last updated: June 25, 2026</p>
+    <p class="date">Last updated: June 26, 2026</p>
 
     <h2>Calculator M3</h2>
     <p>Calculator M3 is a free, open-source calculator app built by Gergely Vagujhelyi.</p>
@@ -25,10 +25,11 @@
     <p>The app includes an optional AI Math Solver. You can photograph a handwritten math expression — using your device's system camera, or by picking an existing photo — and a locally-stored AI model reads and solves it <strong>entirely on your device</strong>. Your photos are never uploaded, and the captured photo is deleted after it is analyzed. If you do not use this feature, it has no effect.</p>
 
     <h2>Internet Access</h2>
-    <p>The calculator works entirely offline and makes no network connections. The only feature that uses the internet is the optional AI Math Solver: when you choose to download an AI model, the app downloads it from a public model host (such as Hugging Face). No personal data is sent during the download, and the model then runs entirely on your device. If you never download an AI model, the app uses no internet at all.</p>
+    <p>The calculator works entirely offline and makes no network connections. The only feature that uses the internet is the optional AI Math Solver: when you choose to download an AI model, the app downloads it from a public model host (such as Hugging Face). The model then runs entirely on your device. If you never download an AI model, the app uses no internet at all.</p>
+    <p>Some models are "gated" and require a one-time sign-in to Hugging Face, which you start yourself. The sign-in happens directly with Hugging Face in a browser tab — your credentials are entered on Hugging Face's own page and are never seen by this app. The app stores only a short-lived access token on your device, used solely to authorize that download.</p>
 
     <h2>Third-Party Services</h2>
-    <p>This app does not use any third-party services, analytics, advertising, or tracking tools. AI models are downloaded from public hosts solely to run on your device; no usage data is shared with them.</p>
+    <p>This app contains no analytics, advertising, or tracking tools. AI models are downloaded from public hosts (such as Hugging Face) solely to run on your device; no usage data is shared with them. If you choose to download a gated model, you sign in to Hugging Face directly, and the app receives only a short-lived download token — never your credentials.</p>
 
     <h2>Permissions</h2>
     <p>The calculator itself requests no special permissions. The optional AI Math Solver uses:</p>

--- a/metadata/en-US/changelogs/12.txt
+++ b/metadata/en-US/changelogs/12.txt
@@ -1,8 +1,9 @@
-New: AI Math Solver — photograph a handwritten math expression and solve it, fully on-device.
+New: AI Math Solver (experimental) — photograph handwritten math and solve it, fully on-device.
 
-- Runs offline on Google LiteRT-LM, GPU-accelerated where supported
-- Take a photo with your camera or choose one from your gallery
-- Pick from several Gemma vision models; downloads run in the background and resume if interrupted
-- Answers are shown with formatted math
+- A hidden extra: some tapping on the keypad reveals it
+- Runs offline on Google LiteRT-LM, GPU-accelerated
+- Snap a photo or pick one from your gallery
+- Several Gemma vision models; background downloads resume if interrupted and can be stopped
+- Gated models unlock with a one-tap Hugging Face sign-in
 
-Your photos and calculations never leave your device — internet is only used to download a model you choose.
+Your photos never leave your device — internet only downloads the model you pick.

--- a/metadata/en-US/changelogs/12.txt
+++ b/metadata/en-US/changelogs/12.txt
@@ -1,6 +1,6 @@
 New: AI Math Solver (experimental) — photograph handwritten math and solve it, fully on-device.
 
-- A hidden extra: some tapping on the keypad reveals it
+- Hidden until you reveal it: tap AC 7 times quickly
 - Runs offline on Google LiteRT-LM, GPU-accelerated
 - Snap a photo or pick one from your gallery
 - Several Gemma vision models; background downloads resume if interrupted and can be stopped

--- a/metadata/en-US/full_description.txt
+++ b/metadata/en-US/full_description.txt
@@ -38,9 +38,10 @@ Type complete mathematical expressions with proper operator precedence (PEMDAS) 
 
 📷 AI MATH SOLVER (OPTIONAL, EXPERIMENTAL)
 
-A hidden, experimental extra for higher-RAM devices: photograph a handwritten math expression and let an on-device AI model read and solve it — entirely on your device, with nothing sent to any server.
+An experimental extra for higher-RAM devices: photograph a handwritten math expression and let an on-device AI model read and solve it — entirely on your device, with nothing sent to any server.
 
-- Hidden by default — a bit of tapping around on the keypad reveals it
+➡️ HOW TO TURN IT ON: the AI features are hidden until you unlock them. In the calculator, tap the "AC" (all-clear) button 7 times in quick succession — a countdown guides the final taps. A camera icon then appears in the top-left corner, and the unlock is remembered.
+
 - Needs a 6 GB+ device and a one-time vision-model download (2.6–4.9 GB)
 - Take a photo with your system camera, or pick one from your gallery
 - Choose from several open vision models (Gemma 4, Gemma 3n)

--- a/metadata/en-US/full_description.txt
+++ b/metadata/en-US/full_description.txt
@@ -36,10 +36,12 @@ Type complete mathematical expressions with proper operator precedence (PEMDAS) 
 - Tap entries to reload them
 - Clear history when needed
 
-📷 AI MATH SOLVER (OPTIONAL)
+📷 AI MATH SOLVER (OPTIONAL, EXPERIMENTAL)
 
-Photograph a handwritten math expression and let an on-device AI model read and solve it — entirely on your device, with nothing sent to any server.
+A hidden, experimental extra for higher-RAM devices: photograph a handwritten math expression and let an on-device AI model read and solve it — entirely on your device, with nothing sent to any server.
 
+- Hidden by default — a bit of tapping around on the keypad reveals it
+- Needs a 6 GB+ device and a one-time vision-model download (2.6–4.9 GB)
 - Take a photo with your system camera, or pick one from your gallery
 - Choose from several open vision models (Gemma 4, Gemma 3n)
 - Models run fully on-device, GPU-accelerated where supported


### PR DESCRIPTION
## What

The whole AI Math Solver — solver, gated-model Hugging Face sign-in, Stop button, RAM checks, and the rapid-AC easter-egg unlock — all land in the still-untagged **1.5.1** (v1.5.0 / versionCode 11 shipped with no AI). The user-facing docs were frozen at the AI solver's first landing (#44) and had drifted out of sync. This brings them up to date with everything merged since.

## Changes

- **README** — document the rapid-AC easter-egg unlock (the camera icon only appears once AI is revealed); fix the model RAM table (Gemma 3n E2B `4→6 GB`, E4B `6→8 GB`) and the `4+ → 6+ GB` requirement to match `minRamGb` / `canRunAnyModel`.
- **Store long description** (`full_description.txt`) — reframe the AI solver as a hidden, experimental extra needing a 6 GB+ device, without spelling out the unlock gesture.
- **Changelog 12** (the 1.5.1 "What's New") — note it's experimental/hidden, plus the Stop button (#62) and one-tap Hugging Face sign-in for gated models (#59). 488 chars, under Play's 500 limit.
- **Privacy policy** — disclose the Hugging Face sign-in flow: credentials are entered on Hugging Face's own page and never seen by the app, which keeps only a short-lived download token. Relaxes the now-inaccurate "no third-party services" / "no personal data sent" claims.

## Verified, left unchanged

- `short_description.txt` — "optional on-device AI" is still accurate for a one-line tagline.
- `docs/huggingface-oauth-setup.md` — matches `HuggingFaceAuth.kt` (redirect URI, scopes, scheme, client ID).
- `title.txt`, F-Droid `.yml` — no feature content; the build entry fills in at release time.