### PR TITLE
Declare NonFreeNet/NonFreeAssets anti-features in F-Droid metadata

### DIFF
--- a/metadata/com.vagujhelyigergely.calculatorm3.yml
+++ b/metadata/com.vagujhelyigergely.calculatorm3.yml
@@ -12,6 +12,16 @@ Repo: https://github.com/gergelyvagujhelyi/CalculatorM3.git
 Binaries: 
   https://github.com/gergelyvagujhelyi/CalculatorM3/releases/download/v%v/app-release.apk
 
+AntiFeatures:
+  NonFreeNet:
+    en-US: >-
+      The optional, off-by-default AI math solver downloads Google Gemma models
+      from Hugging Face at runtime. The calculator itself uses no network.
+  NonFreeAssets:
+    en-US: >-
+      The downloadable Gemma models are covered by the non-free Gemma Terms of
+      Use, not a free-software licence.
+
 Builds:
   - versionName: 1.4.1
     versionCode: 8


### PR DESCRIPTION
## What
Adds the `NonFreeNet` and `NonFreeAssets` anti-feature disclosures to the F-Droid build recipe (`metadata/com.vagujhelyigergely.calculatorm3.yml`).

## Why
The optional, off-by-default AI math solver downloads non-free Google Gemma models from Hugging Face at runtime. F-Droid requires these to be declared:

- **NonFreeNet** — the feature depends on the Hugging Face network service for the model download.
- **NonFreeAssets** — the downloadable Gemma models are covered by the non-free Gemma Terms of Use, not a free-software licence.

The core calculator uses no network and stays fully FOSS (GPL-3.0).
