### PR TITLE
Plain Assistant AI button + notification permission rationale

### DIFF
--- a/app/src/main/java/com/vagujhelyigergely/calculatorm3/CalculatorScreen.kt
+++ b/app/src/main/java/com/vagujhelyigergely/calculatorm3/CalculatorScreen.kt
@@ -18,7 +18,7 @@ import androidx.compose.foundation.gestures.detectTapGestures
 import androidx.compose.ui.input.pointer.pointerInput
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.filled.AccessTime
-import androidx.compose.material.icons.filled.CameraAlt
+import androidx.compose.material.icons.filled.Assistant
 import androidx.compose.material.icons.filled.DeleteOutline
 import androidx.compose.material.icons.filled.Psychology
 import androidx.compose.material3.*
@@ -336,18 +336,11 @@ private fun PortraitLayout(
         ) {
             if (onShowCamera != null) {
                 IconButton(onClick = onShowCamera) {
-                    Box(contentAlignment = Alignment.Center) {
-                        Icon(
-                            painter = painterResource(R.drawable.ic_ai_camera),
-                            contentDescription = stringResource(R.string.scan_expression),
-                            tint = colorScheme.onSurfaceVariant
-                        )
-                        Icon(
-                            painter = painterResource(R.drawable.ic_ai_camera_overlay),
-                            contentDescription = null,
-                            tint = colorScheme.surface
-                        )
-                    }
+                    Icon(
+                        imageVector = Icons.Filled.Assistant,
+                        contentDescription = stringResource(R.string.scan_expression),
+                        tint = colorScheme.onSurfaceVariant
+                    )
                 }
             }
             IconButton(onClick = onShowHistory) {
@@ -431,18 +424,11 @@ private fun LandscapeLayout(
             ) {
                 if (onShowCamera != null) {
                     IconButton(onClick = onShowCamera) {
-                        Box(contentAlignment = Alignment.Center) {
-                            Icon(
-                                painter = painterResource(R.drawable.ic_ai_camera),
-                                contentDescription = stringResource(R.string.scan_expression),
-                                tint = colorScheme.onSurfaceVariant
-                            )
-                            Icon(
-                                painter = painterResource(R.drawable.ic_ai_camera_overlay),
-                                contentDescription = null,
-                                tint = colorScheme.surface
-                            )
-                        }
+                        Icon(
+                            imageVector = Icons.Filled.Assistant,
+                            contentDescription = stringResource(R.string.scan_expression),
+                            tint = colorScheme.onSurfaceVariant
+                        )
                     }
                 }
                 IconButton(onClick = onShowHistory) {

--- a/app/src/main/java/com/vagujhelyigergely/calculatorm3/camera/CameraScanScreen.kt
+++ b/app/src/main/java/com/vagujhelyigergely/calculatorm3/camera/CameraScanScreen.kt
@@ -4,12 +4,14 @@ package com.vagujhelyigergely.calculatorm3.camera
 
 import android.Manifest
 import android.content.Intent
+import android.content.pm.PackageManager
 import android.net.Uri
 import android.os.Build
 import android.widget.TextView
 import androidx.activity.compose.rememberLauncherForActivityResult
 import androidx.activity.result.PickVisualMediaRequest
 import androidx.activity.result.contract.ActivityResultContracts
+import androidx.core.content.ContextCompat
 import androidx.core.content.FileProvider
 import androidx.compose.animation.AnimatedContent
 import androidx.compose.animation.AnimatedVisibility
@@ -42,6 +44,7 @@ import androidx.compose.material.icons.filled.ExpandLess
 import androidx.compose.material.icons.automirrored.filled.Login
 import androidx.compose.material.icons.filled.ExpandMore
 import androidx.compose.material.icons.filled.PhotoCamera
+import androidx.compose.material.icons.filled.Notifications
 import androidx.compose.material.icons.filled.PhotoLibrary
 import androidx.compose.material.icons.filled.Psychology
 import androidx.compose.material.icons.filled.SwapHoriz
@@ -91,6 +94,9 @@ fun CameraScanScreen(
     val notifPermissionLauncher = rememberLauncherForActivityResult(
         ActivityResultContracts.RequestPermission()
     ) { /* best-effort: the download runs regardless of notification visibility */ }
+    // Show a rationale first so the user understands why notifications are requested:
+    // the model download is large and runs in a background service with a progress notification.
+    var showNotifRationale by remember { mutableStateOf(false) }
     // Launches the AppAuth Custom Tab for HuggingFace sign-in; the returned Intent carries
     // the authorization code, which the ViewModel exchanges for a token.
     val signInLauncher = rememberLauncherForActivityResult(
@@ -99,9 +105,32 @@ fun CameraScanScreen(
 
     LaunchedEffect(Unit) {
         viewModel.initialize()
-        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.TIRAMISU) {
-            notifPermissionLauncher.launch(Manifest.permission.POST_NOTIFICATIONS)
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.TIRAMISU &&
+            ContextCompat.checkSelfPermission(context, Manifest.permission.POST_NOTIFICATIONS) !=
+                PackageManager.PERMISSION_GRANTED
+        ) {
+            showNotifRationale = true
         }
+    }
+
+    if (showNotifRationale) {
+        AlertDialog(
+            onDismissRequest = { showNotifRationale = false },
+            icon = { Icon(Icons.Filled.Notifications, contentDescription = null) },
+            title = { Text(stringResource(R.string.notif_permission_title)) },
+            text = { Text(stringResource(R.string.notif_permission_rationale)) },
+            confirmButton = {
+                TextButton(onClick = {
+                    showNotifRationale = false
+                    notifPermissionLauncher.launch(Manifest.permission.POST_NOTIFICATIONS)
+                }) { Text(stringResource(R.string.notif_permission_allow)) }
+            },
+            dismissButton = {
+                TextButton(onClick = { showNotifRationale = false }) {
+                    Text(stringResource(R.string.not_now))
+                }
+            }
+        )
     }
 
     // Keep screen on while the user is actively waiting in-app (model load / inference).

--- a/app/src/main/java/com/vagujhelyigergely/calculatorm3/camera/CameraScanScreen.kt
+++ b/app/src/main/java/com/vagujhelyigergely/calculatorm3/camera/CameraScanScreen.kt
@@ -91,12 +91,31 @@ fun CameraScanScreen(
     onDismiss: () -> Unit
 ) {
     val context = LocalContext.current
+    // Model whose download is queued behind the notification-permission flow.
+    var pendingDownloadModel by remember { mutableStateOf<AiModel?>(null) }
+    var showNotifRationale by remember { mutableStateOf(false) }
     val notifPermissionLauncher = rememberLauncherForActivityResult(
         ActivityResultContracts.RequestPermission()
-    ) { /* best-effort: the download runs regardless of notification visibility */ }
-    // Show a rationale first so the user understands why notifications are requested:
-    // the model download is large and runs in a background service with a progress notification.
-    var showNotifRationale by remember { mutableStateOf(false) }
+    ) {
+        // Start the queued download regardless of the result — the notification only shows
+        // progress; the download itself runs either way.
+        pendingDownloadModel?.let { viewModel.startDownload(it) }
+        pendingDownloadModel = null
+    }
+    // Start a model download. On Android 13+ without notification permission, first explain why
+    // we ask (the download is large and runs in a background service with a progress
+    // notification), then request it. Pre-Tiramisu or already-granted: download straight away.
+    val startDownloadWithNotifPrompt: (AiModel) -> Unit = { model ->
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.TIRAMISU &&
+            ContextCompat.checkSelfPermission(context, Manifest.permission.POST_NOTIFICATIONS) !=
+                PackageManager.PERMISSION_GRANTED
+        ) {
+            pendingDownloadModel = model
+            showNotifRationale = true
+        } else {
+            viewModel.startDownload(model)
+        }
+    }
     // Launches the AppAuth Custom Tab for HuggingFace sign-in; the returned Intent carries
     // the authorization code, which the ViewModel exchanges for a token.
     val signInLauncher = rememberLauncherForActivityResult(
@@ -105,17 +124,17 @@ fun CameraScanScreen(
 
     LaunchedEffect(Unit) {
         viewModel.initialize()
-        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.TIRAMISU &&
-            ContextCompat.checkSelfPermission(context, Manifest.permission.POST_NOTIFICATIONS) !=
-                PackageManager.PERMISSION_GRANTED
-        ) {
-            showNotifRationale = true
-        }
     }
 
     if (showNotifRationale) {
+        // Proceed with the queued download whether the user allows, declines, or dismisses.
+        val proceedWithoutPermission = {
+            showNotifRationale = false
+            pendingDownloadModel?.let { viewModel.startDownload(it) }
+            pendingDownloadModel = null
+        }
         AlertDialog(
-            onDismissRequest = { showNotifRationale = false },
+            onDismissRequest = proceedWithoutPermission,
             icon = { Icon(Icons.Filled.Notifications, contentDescription = null) },
             title = { Text(stringResource(R.string.notif_permission_title)) },
             text = { Text(stringResource(R.string.notif_permission_rationale)) },
@@ -126,7 +145,7 @@ fun CameraScanScreen(
                 }) { Text(stringResource(R.string.notif_permission_allow)) }
             },
             dismissButton = {
-                TextButton(onClick = { showNotifRationale = false }) {
+                TextButton(onClick = proceedWithoutPermission) {
                     Text(stringResource(R.string.not_now))
                 }
             }
@@ -239,7 +258,7 @@ fun CameraScanScreen(
                             is ScanUiState.AuthError -> AuthErrorContent(
                                 httpCode = state.httpCode,
                                 model = state.model,
-                                onRetry = { viewModel.startDownload(state.model) },
+                                onRetry = { startDownloadWithNotifPrompt(state.model) },
                                 onReauth = { viewModel.showSignIn(state.model) },
                                 onDismiss = onDismiss
                             )
@@ -274,7 +293,7 @@ fun CameraScanScreen(
                                 downloadedModels = state.downloadedModels,
                                 deviceRamGb = state.deviceRamGb,
                                 onSelectModel = { viewModel.selectModel(it) },
-                                onDownloadModel = { viewModel.startDownload(it) },
+                                onDownloadModel = startDownloadWithNotifPrompt,
                                 onDismiss = onDismiss
                             )
                         }

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -59,6 +59,10 @@
     <string name="download_complete">Download complete</string>
     <string name="download_file_progress">File %1$d of %2$d</string>
     <string name="download_warning">This is a large download. Use Wi-Fi if possible.</string>
+    <string name="notif_permission_title">Allow notifications?</string>
+    <string name="notif_permission_rationale">Allow notifications so the AI model download can run in the background and show its progress.</string>
+    <string name="notif_permission_allow">Allow</string>
+    <string name="not_now">Not now</string>
     <string name="raw_model_output">Raw model output</string>
     <string name="models_group_gemma4">Gemma 4</string>
     <string name="models_group_login">Needs HuggingFace login</string>


### PR DESCRIPTION
Two AI-feature UX changes, verified on a physical Galaxy Note 9 (Android 13).

## AI entry button → plain Assistant icon
Replaces the custom camera glyph with `Icons.Filled.Assistant` (bubble + sparkle) in both the portrait and landscape top bars, matching the History button's plain, no-container style.

## Notification permission rationale
Before requesting `POST_NOTIFICATIONS`, show a Material 3 dialog explaining that notifications let the AI model download keep running in the background and show progress (**Not now** / **Allow**). It only appears when the permission isn't already granted, instead of cold-launching the system prompt the moment the scan screen opens.

Adds 4 strings. The now-unused `ic_ai_camera*` drawables are left in place (not removed in this PR).
