### PR TITLE
Localize the AI-scan error messages (17 locales)

### DIFF
--- a/app/src/main/java/com/vagujhelyigergely/calculatorm3/MainActivity.kt
+++ b/app/src/main/java/com/vagujhelyigergely/calculatorm3/MainActivity.kt
@@ -62,6 +62,6 @@ class ScanViewModelFactory(
 ) : ViewModelProvider.Factory {
     override fun <T : ViewModel> create(modelClass: Class<T>): T {
         @Suppress("UNCHECKED_CAST")
-        return ScanViewModel(LiteRTSolver(), modelManager, HuggingFaceAuthManager(appContext)) as T
+        return ScanViewModel(LiteRTSolver(), modelManager, HuggingFaceAuthManager(appContext), appContext) as T
     }
 }

--- a/app/src/main/java/com/vagujhelyigergely/calculatorm3/ai/LiteRTSolver.kt
+++ b/app/src/main/java/com/vagujhelyigergely/calculatorm3/ai/LiteRTSolver.kt
@@ -1,6 +1,7 @@
 package com.vagujhelyigergely.calculatorm3.ai
 
 import android.util.Log
+import com.vagujhelyigergely.calculatorm3.R
 import com.google.ai.edge.litertlm.Backend
 import com.google.ai.edge.litertlm.Content
 import com.google.ai.edge.litertlm.Contents
@@ -115,7 +116,8 @@ class LiteRTSolver : MathSolver {
         val raw = rawBuilder.toString()
         val answer = SolverPrompts.extractAnswer(raw)
         return if (answer.isBlank()) {
-            Result.failure(RecognitionException("Could not extract a numerical answer", raw))
+            Result.failure(RecognitionException(
+                "Could not extract a numerical answer", raw, R.string.error_no_numerical_answer))
         } else {
             Result.success(RecognitionResult(raw = raw, answer = answer))
         }

--- a/app/src/main/java/com/vagujhelyigergely/calculatorm3/ai/MathSolver.kt
+++ b/app/src/main/java/com/vagujhelyigergely/calculatorm3/ai/MathSolver.kt
@@ -1,8 +1,18 @@
 package com.vagujhelyigergely.calculatorm3.ai
 
+import androidx.annotation.StringRes
+
 data class RecognitionResult(val raw: String, val answer: String)
 
-class RecognitionException(message: String, val rawResponse: String) : Exception(message)
+/**
+ * [messageRes], when non-zero, is a localized string resource the UI resolves (the solver has no
+ * Context). [message] is the English fallback for callers that don't carry a resource id.
+ */
+class RecognitionException(
+    message: String,
+    val rawResponse: String,
+    @StringRes val messageRes: Int = 0,
+) : Exception(message)
 
 /**
  * Common interface for AI backends that solve handwritten math from images.

--- a/app/src/main/java/com/vagujhelyigergely/calculatorm3/camera/ScanViewModel.kt
+++ b/app/src/main/java/com/vagujhelyigergely/calculatorm3/camera/ScanViewModel.kt
@@ -71,8 +71,12 @@ class ScanViewModel(
     private val solver: MathSolver,
     private val modelManager: ModelManager,
     private val authManager: HuggingFaceAuthManager,
-    private val appContext: Context
+    context: Context
 ) : ViewModel() {
+
+    // Store the *application* context so the ViewModel can outlive an Activity without leaking it.
+    // The factory already passes applicationContext; this makes it safe regardless of caller.
+    private val appContext = context.applicationContext
 
     var uiState by mutableStateOf<ScanUiState>(ScanUiState.Idle)
         private set

--- a/app/src/main/java/com/vagujhelyigergely/calculatorm3/camera/ScanViewModel.kt
+++ b/app/src/main/java/com/vagujhelyigergely/calculatorm3/camera/ScanViewModel.kt
@@ -1,5 +1,6 @@
 package com.vagujhelyigergely.calculatorm3.camera
 
+import android.content.Context
 import android.content.Intent
 import android.graphics.Bitmap
 import android.graphics.BitmapFactory
@@ -9,6 +10,7 @@ import androidx.compose.runtime.setValue
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
 import androidx.work.WorkInfo
+import com.vagujhelyigergely.calculatorm3.R
 import com.vagujhelyigergely.calculatorm3.ai.AiModel
 import com.vagujhelyigergely.calculatorm3.ai.MathSolver
 import com.vagujhelyigergely.calculatorm3.ai.ModelDownloadWorker
@@ -68,7 +70,8 @@ sealed interface ScanUiState {
 class ScanViewModel(
     private val solver: MathSolver,
     private val modelManager: ModelManager,
-    private val authManager: HuggingFaceAuthManager
+    private val authManager: HuggingFaceAuthManager,
+    private val appContext: Context
 ) : ViewModel() {
 
     var uiState by mutableStateOf<ScanUiState>(ScanUiState.Idle)
@@ -125,7 +128,7 @@ class ScanViewModel(
             // finally releases the engine) instead of surfacing it as a load error.
             if (e is kotlinx.coroutines.CancellationException) throw e
             loadedModelId = null
-            uiState = ScanUiState.Error("Failed to load AI model: ${e.message}")
+            uiState = ScanUiState.Error(appContext.getString(R.string.error_model_load, e.message ?: ""))
             false
         }
     }
@@ -176,7 +179,8 @@ class ScanViewModel(
                 startDownload(model)
             } catch (e: Exception) {
                 if (e is kotlinx.coroutines.CancellationException) throw e
-                uiState = ScanUiState.Error("Sign-in failed: ${e.message ?: "please try again"}")
+                uiState = ScanUiState.Error(appContext.getString(
+                    R.string.error_signin_failed, e.message ?: appContext.getString(R.string.please_try_again)))
             }
         }
     }
@@ -267,9 +271,10 @@ class ScanViewModel(
                                 model = m
                             )
                         } else {
-                            uiState = ScanUiState.Error(
-                                "Download failed: ${out.getString(ModelDownloadWorker.KEY_MESSAGE) ?: ""}"
-                            )
+                            uiState = ScanUiState.Error(appContext.getString(
+                                R.string.error_download_failed,
+                                out.getString(ModelDownloadWorker.KEY_MESSAGE) ?: ""
+                            ))
                         }
                     }
                     WorkInfo.State.CANCELLED, null -> { /* nothing to show */ }
@@ -305,7 +310,7 @@ class ScanViewModel(
                 if (processPath == null) {
                     // Preprocessing failed — do NOT fall back to the original full-resolution
                     // photo, which can OOM the vision pipeline. Surface an error instead.
-                    uiState = ScanUiState.Error("Couldn't process that image. Please try another photo.")
+                    uiState = ScanUiState.Error(appContext.getString(R.string.error_image_process))
                     return@launch
                 }
                 var tokenCount = 0
@@ -359,14 +364,17 @@ class ScanViewModel(
                     },
                     onFailure = {
                         val raw = (it as? RecognitionException)?.rawResponse
-                        ScanUiState.Error(it.message ?: "Recognition failed", raw)
+                        val res = (it as? RecognitionException)?.messageRes ?: 0
+                        val msg = if (res != 0) appContext.getString(res)
+                            else it.message ?: appContext.getString(R.string.recognition_error)
+                        ScanUiState.Error(msg, raw)
                     }
                 )
             } catch (e: Throwable) {
                 // Let cancellation (e.g. user closed the screen) propagate instead
                 // of showing it as an inference error.
                 if (e is kotlinx.coroutines.CancellationException) throw e
-                uiState = ScanUiState.Error("Inference failed: ${e.message}")
+                uiState = ScanUiState.Error(appContext.getString(R.string.error_inference_failed, e.message ?: ""))
             } finally {
                 // Free the engine as soon as inference is done: it must NOT stay resident while
                 // the system camera launches for the next scan (large models OOM-kill the app —
@@ -468,7 +476,7 @@ class ScanViewModel(
     }
 
     fun onCaptureError(message: String) {
-        uiState = ScanUiState.Error("Capture failed: $message")
+        uiState = ScanUiState.Error(appContext.getString(R.string.error_capture_failed, message))
     }
 
     fun retry() {

--- a/app/src/main/res/values-de/strings.xml
+++ b/app/src/main/res/values-de/strings.xml
@@ -90,4 +90,12 @@
         <item quantity="one">Noch %1$d Tastendruck, um die KI-Funktionen freizuschalten</item>
         <item quantity="other">Noch %1$d Tastendrücke, um die KI-Funktionen freizuschalten</item>
     </plurals>
+    <string name="error_no_numerical_answer">Es konnte keine Zahl als Ergebnis erkannt werden</string>
+    <string name="error_model_load">KI-Modell konnte nicht geladen werden: %1$s</string>
+    <string name="error_signin_failed">Anmeldung fehlgeschlagen: %1$s</string>
+    <string name="please_try_again">bitte erneut versuchen</string>
+    <string name="error_download_failed">Download fehlgeschlagen: %1$s</string>
+    <string name="error_image_process">Dieses Bild konnte nicht verarbeitet werden. Bitte versuche ein anderes Foto.</string>
+    <string name="error_inference_failed">Inferenz fehlgeschlagen: %1$s</string>
+    <string name="error_capture_failed">Aufnahme fehlgeschlagen: %1$s</string>
 </resources>

--- a/app/src/main/res/values-es/strings.xml
+++ b/app/src/main/res/values-es/strings.xml
@@ -90,4 +90,12 @@
         <item quantity="one">Te queda %1$d pulsación para desbloquear las funciones de IA</item>
         <item quantity="other">Te quedan %1$d pulsaciones para desbloquear las funciones de IA</item>
     </plurals>
+    <string name="error_no_numerical_answer">No se pudo extraer una respuesta numérica</string>
+    <string name="error_model_load">No se pudo cargar el modelo de IA: %1$s</string>
+    <string name="error_signin_failed">Error al iniciar sesión: %1$s</string>
+    <string name="please_try_again">inténtalo de nuevo</string>
+    <string name="error_download_failed">Error en la descarga: %1$s</string>
+    <string name="error_image_process">No se pudo procesar esa imagen. Prueba con otra foto.</string>
+    <string name="error_inference_failed">Error de inferencia: %1$s</string>
+    <string name="error_capture_failed">Error al capturar: %1$s</string>
 </resources>

--- a/app/src/main/res/values-fr/strings.xml
+++ b/app/src/main/res/values-fr/strings.xml
@@ -90,4 +90,12 @@
         <item quantity="one">Encore %1$d appui pour débloquer les fonctions IA</item>
         <item quantity="other">Encore %1$d appuis pour débloquer les fonctions IA</item>
     </plurals>
+    <string name="error_no_numerical_answer">Impossible d\'extraire une réponse numérique</string>
+    <string name="error_model_load">Échec du chargement du modèle d\'IA : %1$s</string>
+    <string name="error_signin_failed">Échec de la connexion : %1$s</string>
+    <string name="please_try_again">veuillez réessayer</string>
+    <string name="error_download_failed">Échec du téléchargement : %1$s</string>
+    <string name="error_image_process">Impossible de traiter cette image. Veuillez essayer une autre photo.</string>
+    <string name="error_inference_failed">Échec de l\'inférence : %1$s</string>
+    <string name="error_capture_failed">Échec de la capture : %1$s</string>
 </resources>

--- a/app/src/main/res/values-hi/strings.xml
+++ b/app/src/main/res/values-hi/strings.xml
@@ -90,4 +90,12 @@
         <item quantity="one">AI सुविधाएँ अनलॉक करने के लिए %1$d बार और टैप करें</item>
         <item quantity="other">AI सुविधाएँ अनलॉक करने के लिए %1$d बार और टैप करें</item>
     </plurals>
+    <string name="error_no_numerical_answer">कोई संख्यात्मक उत्तर नहीं निकाला जा सका</string>
+    <string name="error_model_load">AI मॉडल लोड नहीं हो सका: %1$s</string>
+    <string name="error_signin_failed">साइन-इन विफल: %1$s</string>
+    <string name="please_try_again">कृपया पुनः प्रयास करें</string>
+    <string name="error_download_failed">डाउनलोड विफल: %1$s</string>
+    <string name="error_image_process">वह छवि संसाधित नहीं हो सकी। कृपया कोई दूसरी फ़ोटो आज़माएँ।</string>
+    <string name="error_inference_failed">अनुमान विफल: %1$s</string>
+    <string name="error_capture_failed">कैप्चर विफल: %1$s</string>
 </resources>

--- a/app/src/main/res/values-hu/strings.xml
+++ b/app/src/main/res/values-hu/strings.xml
@@ -90,4 +90,12 @@
         <item quantity="one">Még %1$d megnyomás az MI-funkciók feloldásához</item>
         <item quantity="other">Még %1$d megnyomás az MI-funkciók feloldásához</item>
     </plurals>
+    <string name="error_no_numerical_answer">Nem sikerült számszerű választ kinyerni</string>
+    <string name="error_model_load">Nem sikerült betölteni az MI-modellt: %1$s</string>
+    <string name="error_signin_failed">A bejelentkezés sikertelen: %1$s</string>
+    <string name="please_try_again">kérjük, próbáld újra</string>
+    <string name="error_download_failed">A letöltés sikertelen: %1$s</string>
+    <string name="error_image_process">Nem sikerült feldolgozni a képet. Próbálj meg egy másik fotót.</string>
+    <string name="error_inference_failed">A következtetés sikertelen: %1$s</string>
+    <string name="error_capture_failed">A rögzítés sikertelen: %1$s</string>
 </resources>

--- a/app/src/main/res/values-in/strings.xml
+++ b/app/src/main/res/values-in/strings.xml
@@ -89,4 +89,12 @@
     <plurals name="ai_unlock_countdown">
         <item quantity="other">%1$d ketukan lagi untuk membuka fitur AI</item>
     </plurals>
+    <string name="error_no_numerical_answer">Tidak dapat menemukan jawaban berupa angka</string>
+    <string name="error_model_load">Gagal memuat model AI: %1$s</string>
+    <string name="error_signin_failed">Gagal masuk: %1$s</string>
+    <string name="please_try_again">silakan coba lagi</string>
+    <string name="error_download_failed">Gagal mengunduh: %1$s</string>
+    <string name="error_image_process">Tidak dapat memproses gambar itu. Coba foto lain.</string>
+    <string name="error_inference_failed">Inferensi gagal: %1$s</string>
+    <string name="error_capture_failed">Gagal mengambil gambar: %1$s</string>
 </resources>

--- a/app/src/main/res/values-it/strings.xml
+++ b/app/src/main/res/values-it/strings.xml
@@ -90,4 +90,12 @@
         <item quantity="one">Manca %1$d pressione per sbloccare le funzioni IA</item>
         <item quantity="other">Mancano %1$d pressioni per sbloccare le funzioni IA</item>
     </plurals>
+    <string name="error_no_numerical_answer">Impossibile estrarre una risposta numerica</string>
+    <string name="error_model_load">Impossibile caricare il modello IA: %1$s</string>
+    <string name="error_signin_failed">Accesso non riuscito: %1$s</string>
+    <string name="please_try_again">riprova</string>
+    <string name="error_download_failed">Download non riuscito: %1$s</string>
+    <string name="error_image_process">Impossibile elaborare l\'immagine. Prova un\'altra foto.</string>
+    <string name="error_inference_failed">Inferenza non riuscita: %1$s</string>
+    <string name="error_capture_failed">Acquisizione non riuscita: %1$s</string>
 </resources>

--- a/app/src/main/res/values-ja/strings.xml
+++ b/app/src/main/res/values-ja/strings.xml
@@ -89,4 +89,12 @@
     <plurals name="ai_unlock_countdown">
         <item quantity="other">AI機能のロック解除まであと %1$d 回</item>
     </plurals>
+    <string name="error_no_numerical_answer">数値の答えを読み取れませんでした</string>
+    <string name="error_model_load">AIモデルの読み込みに失敗しました: %1$s</string>
+    <string name="error_signin_failed">サインインに失敗しました: %1$s</string>
+    <string name="please_try_again">もう一度お試しください</string>
+    <string name="error_download_failed">ダウンロードに失敗しました: %1$s</string>
+    <string name="error_image_process">その画像を処理できませんでした。別の写真でお試しください。</string>
+    <string name="error_inference_failed">推論に失敗しました: %1$s</string>
+    <string name="error_capture_failed">撮影に失敗しました: %1$s</string>
 </resources>

--- a/app/src/main/res/values-ko/strings.xml
+++ b/app/src/main/res/values-ko/strings.xml
@@ -89,4 +89,12 @@
     <plurals name="ai_unlock_countdown">
         <item quantity="other">AI 기능 잠금 해제까지 %1$d번 남았습니다</item>
     </plurals>
+    <string name="error_no_numerical_answer">숫자 답을 추출할 수 없습니다</string>
+    <string name="error_model_load">AI 모델을 불러오지 못했습니다: %1$s</string>
+    <string name="error_signin_failed">로그인 실패: %1$s</string>
+    <string name="please_try_again">다시 시도해 주세요</string>
+    <string name="error_download_failed">다운로드 실패: %1$s</string>
+    <string name="error_image_process">이미지를 처리할 수 없습니다. 다른 사진을 사용해 보세요.</string>
+    <string name="error_inference_failed">추론 실패: %1$s</string>
+    <string name="error_capture_failed">촬영 실패: %1$s</string>
 </resources>

--- a/app/src/main/res/values-nl/strings.xml
+++ b/app/src/main/res/values-nl/strings.xml
@@ -90,4 +90,12 @@
         <item quantity="one">Nog %1$d tik om de AI-functies te ontgrendelen</item>
         <item quantity="other">Nog %1$d tikken om de AI-functies te ontgrendelen</item>
     </plurals>
+    <string name="error_no_numerical_answer">Kon geen numeriek antwoord herkennen</string>
+    <string name="error_model_load">Kan AI-model niet laden: %1$s</string>
+    <string name="error_signin_failed">Aanmelden mislukt: %1$s</string>
+    <string name="please_try_again">probeer het opnieuw</string>
+    <string name="error_download_failed">Download mislukt: %1$s</string>
+    <string name="error_image_process">Kan die afbeelding niet verwerken. Probeer een andere foto.</string>
+    <string name="error_inference_failed">Inferentie mislukt: %1$s</string>
+    <string name="error_capture_failed">Vastleggen mislukt: %1$s</string>
 </resources>

--- a/app/src/main/res/values-pl/strings.xml
+++ b/app/src/main/res/values-pl/strings.xml
@@ -92,4 +92,12 @@
         <item quantity="many">Pozostało %1$d naciśnięć do odblokowania funkcji AI</item>
         <item quantity="other">Pozostało %1$d naciśnięć do odblokowania funkcji AI</item>
     </plurals>
+    <string name="error_no_numerical_answer">Nie udało się odczytać odpowiedzi liczbowej</string>
+    <string name="error_model_load">Nie udało się załadować modelu AI: %1$s</string>
+    <string name="error_signin_failed">Logowanie nie powiodło się: %1$s</string>
+    <string name="please_try_again">spróbuj ponownie</string>
+    <string name="error_download_failed">Pobieranie nie powiodło się: %1$s</string>
+    <string name="error_image_process">Nie udało się przetworzyć tego zdjęcia. Spróbuj innego.</string>
+    <string name="error_inference_failed">Wnioskowanie nie powiodło się: %1$s</string>
+    <string name="error_capture_failed">Przechwytywanie nie powiodło się: %1$s</string>
 </resources>

--- a/app/src/main/res/values-pt-rBR/strings.xml
+++ b/app/src/main/res/values-pt-rBR/strings.xml
@@ -90,4 +90,12 @@
         <item quantity="one">Falta %1$d toque para desbloquear os recursos de IA</item>
         <item quantity="other">Faltam %1$d toques para desbloquear os recursos de IA</item>
     </plurals>
+    <string name="error_no_numerical_answer">Não foi possível extrair uma resposta numérica</string>
+    <string name="error_model_load">Falha ao carregar o modelo de IA: %1$s</string>
+    <string name="error_signin_failed">Falha ao entrar: %1$s</string>
+    <string name="please_try_again">tente novamente</string>
+    <string name="error_download_failed">Falha no download: %1$s</string>
+    <string name="error_image_process">Não foi possível processar essa imagem. Tente outra foto.</string>
+    <string name="error_inference_failed">Falha na inferência: %1$s</string>
+    <string name="error_capture_failed">Falha na captura: %1$s</string>
 </resources>

--- a/app/src/main/res/values-ru/strings.xml
+++ b/app/src/main/res/values-ru/strings.xml
@@ -92,4 +92,12 @@
         <item quantity="many">Осталось %1$d нажатий до разблокировки функций ИИ</item>
         <item quantity="other">Осталось %1$d нажатий до разблокировки функций ИИ</item>
     </plurals>
+    <string name="error_no_numerical_answer">Не удалось распознать числовой ответ</string>
+    <string name="error_model_load">Не удалось загрузить модель ИИ: %1$s</string>
+    <string name="error_signin_failed">Не удалось войти: %1$s</string>
+    <string name="please_try_again">попробуйте ещё раз</string>
+    <string name="error_download_failed">Не удалось скачать: %1$s</string>
+    <string name="error_image_process">Не удалось обработать это изображение. Попробуйте другое фото.</string>
+    <string name="error_inference_failed">Ошибка вывода: %1$s</string>
+    <string name="error_capture_failed">Не удалось сделать снимок: %1$s</string>
 </resources>

--- a/app/src/main/res/values-tr/strings.xml
+++ b/app/src/main/res/values-tr/strings.xml
@@ -90,4 +90,12 @@
         <item quantity="one">Yapay zeka özelliklerinin kilidini açmaya %1$d dokunuş kaldı</item>
         <item quantity="other">Yapay zeka özelliklerinin kilidini açmaya %1$d dokunuş kaldı</item>
     </plurals>
+    <string name="error_no_numerical_answer">Sayısal bir yanıt çıkarılamadı</string>
+    <string name="error_model_load">Yapay zekâ modeli yüklenemedi: %1$s</string>
+    <string name="error_signin_failed">Oturum açılamadı: %1$s</string>
+    <string name="please_try_again">lütfen tekrar deneyin</string>
+    <string name="error_download_failed">İndirme başarısız: %1$s</string>
+    <string name="error_image_process">Bu görüntü işlenemedi. Lütfen başka bir fotoğraf deneyin.</string>
+    <string name="error_inference_failed">Çıkarım başarısız: %1$s</string>
+    <string name="error_capture_failed">Yakalama başarısız: %1$s</string>
 </resources>

--- a/app/src/main/res/values-uk/strings.xml
+++ b/app/src/main/res/values-uk/strings.xml
@@ -92,4 +92,12 @@
         <item quantity="many">Залишилося %1$d натискань до розблокування функцій ШІ</item>
         <item quantity="other">Залишилося %1$d натискань до розблокування функцій ШІ</item>
     </plurals>
+    <string name="error_no_numerical_answer">Не вдалося розпізнати числову відповідь</string>
+    <string name="error_model_load">Не вдалося завантажити модель ШІ: %1$s</string>
+    <string name="error_signin_failed">Не вдалося ввійти: %1$s</string>
+    <string name="please_try_again">повторіть спробу</string>
+    <string name="error_download_failed">Не вдалося завантажити: %1$s</string>
+    <string name="error_image_process">Не вдалося обробити це зображення. Спробуйте інше фото.</string>
+    <string name="error_inference_failed">Помилка висновку: %1$s</string>
+    <string name="error_capture_failed">Не вдалося зробити знімок: %1$s</string>
 </resources>

--- a/app/src/main/res/values-vi/strings.xml
+++ b/app/src/main/res/values-vi/strings.xml
@@ -89,4 +89,12 @@
     <plurals name="ai_unlock_countdown">
         <item quantity="other">Còn %1$d lần nhấn nữa để mở khóa tính năng AI</item>
     </plurals>
+    <string name="error_no_numerical_answer">Không thể trích xuất câu trả lời dạng số</string>
+    <string name="error_model_load">Không tải được mô hình AI: %1$s</string>
+    <string name="error_signin_failed">Đăng nhập thất bại: %1$s</string>
+    <string name="please_try_again">vui lòng thử lại</string>
+    <string name="error_download_failed">Tải xuống thất bại: %1$s</string>
+    <string name="error_image_process">Không thể xử lý ảnh đó. Vui lòng thử ảnh khác.</string>
+    <string name="error_inference_failed">Suy luận thất bại: %1$s</string>
+    <string name="error_capture_failed">Chụp thất bại: %1$s</string>
 </resources>

--- a/app/src/main/res/values-zh-rCN/strings.xml
+++ b/app/src/main/res/values-zh-rCN/strings.xml
@@ -89,4 +89,12 @@
     <plurals name="ai_unlock_countdown">
         <item quantity="other">还需按 %1$d 次即可解锁 AI 功能</item>
     </plurals>
+    <string name="error_no_numerical_answer">无法识别出数字答案</string>
+    <string name="error_model_load">无法加载 AI 模型：%1$s</string>
+    <string name="error_signin_failed">登录失败：%1$s</string>
+    <string name="please_try_again">请重试</string>
+    <string name="error_download_failed">下载失败：%1$s</string>
+    <string name="error_image_process">无法处理该图片。请尝试其他照片。</string>
+    <string name="error_inference_failed">推理失败：%1$s</string>
+    <string name="error_capture_failed">拍摄失败：%1$s</string>
 </resources>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -46,6 +46,14 @@
     <string name="stop">Stop</string>
     <string name="close">Close</string>
     <string name="recognition_error">Recognition failed</string>
+    <string name="error_no_numerical_answer">Could not extract a numerical answer</string>
+    <string name="error_model_load">Failed to load AI model: %1$s</string>
+    <string name="error_signin_failed">Sign-in failed: %1$s</string>
+    <string name="please_try_again">please try again</string>
+    <string name="error_download_failed">Download failed: %1$s</string>
+    <string name="error_image_process">Couldn\'t process that image. Please try another photo.</string>
+    <string name="error_inference_failed">Inference failed: %1$s</string>
+    <string name="error_capture_failed">Capture failed: %1$s</string>
     <string name="choose_model">Choose AI model</string>
     <string name="choose_model_description">Your device has %1$d GB RAM. Larger models are more accurate but slower. All models run entirely on your device.</string>
     <string name="model_too_large">Needs %1$d GB RAM — your device has %2$d GB</string>


### PR DESCRIPTION
The AI-scan flow surfaced its errors as **hardcoded English** even though the rest of the app is localized into 17 locales — model-load, sign-in, download, image-process, inference, capture failures, and the solver's *"Could not extract a numerical answer"*.

## Change
- **`ScanViewModel`** now takes the app `Context` (wired from the existing factory) and resolves `R.string.*` for its error states.
- **`RecognitionException`** gains an optional `@StringRes messageRes` (the solver has no `Context`); `ScanViewModel` resolves it. It **defaults to `0`**, so existing `String`-based callers are unaffected — this keeps it conflict-free with the safeguards in #76 (those messages are a follow-up).
- Adds **8 new strings**, translated into **all 17 locales** (de, es, fr, hi, hu, in, it, ja, ko, nl, pl, pt-BR, ru, tr, uk, vi, zh-CN).

## Notes
- `recognition_error` ("Recognition failed") already existed and is reused.
- Builds clean; `%1$s` placeholders verified consistent across all locales.
- 🔎 Translations were generated — worth a spot-check on the languages you read.

Follow-up: localize the cap/timeout safeguard messages once #76 merges (they currently pass plain English strings, which `messageRes=0` handles).
