### PR TITLE
Generation safeguards: output-token cap + timeouts + background-stop (re-target to develop)

### DIFF
--- a/app/src/main/java/com/vagujhelyigergely/calculatorm3/ai/LiteRTSolver.kt
+++ b/app/src/main/java/com/vagujhelyigergely/calculatorm3/ai/LiteRTSolver.kt
@@ -141,7 +141,9 @@ class LiteRTSolver : MathSolver {
                     if (++tokenCount >= MAX_OUTPUT_TOKENS) {
                         capReached = true
                         Log.w(TAG, "Output cap reached ($tokenCount tokens) — stopping generation")
-                        try { conv.cancelProcess() } catch (_: Exception) {}
+                        // catch Throwable, not Exception: cancelProcess() is a native JNI call and
+                        // could surface an Error (e.g. linkage); this best-effort signal must never crash.
+                        try { conv.cancelProcess() } catch (_: Throwable) {}
                         throw OutputCapReached()
                     }
                 }
@@ -168,7 +170,9 @@ class LiteRTSolver : MathSolver {
                 if (tripped != null) {
                     timeoutKind.set(tripped)
                     Log.w(TAG, "watchdog: $tripped budget exceeded — stopping generation")
-                    try { conv.cancelProcess() } catch (_: Exception) {}
+                    // catch Throwable, not Exception: cancelProcess() is a native JNI call and could
+                    // surface an Error (e.g. linkage); this best-effort signal must never crash.
+                    try { conv.cancelProcess() } catch (_: Throwable) {}
                     collectJob.cancel()
                     break
                 }

--- a/app/src/main/java/com/vagujhelyigergely/calculatorm3/ai/LiteRTSolver.kt
+++ b/app/src/main/java/com/vagujhelyigergely/calculatorm3/ai/LiteRTSolver.kt
@@ -1,6 +1,8 @@
 package com.vagujhelyigergely.calculatorm3.ai
 
+import android.os.SystemClock
 import android.util.Log
+import androidx.annotation.StringRes
 import com.vagujhelyigergely.calculatorm3.R
 import com.google.ai.edge.litertlm.Backend
 import com.google.ai.edge.litertlm.Content
@@ -11,10 +13,16 @@ import com.google.ai.edge.litertlm.Engine
 import com.google.ai.edge.litertlm.EngineConfig
 import com.google.ai.edge.litertlm.SamplerConfig
 import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.coroutineScope
+import kotlinx.coroutines.delay
 import kotlinx.coroutines.isActive
+import kotlinx.coroutines.launch
 import kotlinx.coroutines.sync.Mutex
 import kotlinx.coroutines.sync.withLock
 import kotlinx.coroutines.withContext
+import java.util.concurrent.atomic.AtomicBoolean
+import java.util.concurrent.atomic.AtomicLong
+import java.util.concurrent.atomic.AtomicReference
 
 /**
  * MathSolver backend using Google LiteRT-LM for .litertlm models.
@@ -98,24 +106,103 @@ class LiteRTSolver : MathSolver {
     private suspend fun runInference(
         imagePath: String,
         onToken: suspend (partialRaw: String) -> Unit
-    ): Result<RecognitionResult> {
+    ): Result<RecognitionResult> = coroutineScope {
         val conv = createConversation()
         val rawBuilder = StringBuilder()
-        conv.sendMessageAsync(
-            Contents.of(
-                Content.ImageFile(imagePath),
-                Content.Text(SolverPrompts.USER_PROMPT)
+        var tokenCount = 0
+        var capReached = false
+        // Safeguard state, shared with the watchdog. elapsedRealtime() is monotonic (immune to
+        // wall-clock changes). Atomics because the watchdog reads them from another thread.
+        val startMs = SystemClock.elapsedRealtime()
+        val lastActivityMs = AtomicLong(startMs)
+        val firstTokenSeen = AtomicBoolean(false)
+        val timeoutKind = AtomicReference<TimeoutKind?>(null)
+
+        // The token stream is collected in a CHILD job so the watchdog can cancel it on a stall.
+        // cancelProcess() alone does NOT complete the litertlm flow (verified: the scan hangs on
+        // "Processing"), so a stuck collect can only be unwound by cancelling its coroutine.
+        val collectJob = launch {
+            try {
+                conv.sendMessageAsync(
+                    Contents.of(
+                        Content.ImageFile(imagePath),
+                        Content.Text(SolverPrompts.USER_PROMPT)
+                    )
+                ).collect { message ->
+                    val text = message.contents.contents
+                        .filterIsInstance<Content.Text>()
+                        .joinToString("") { it.text }
+                    rawBuilder.append(text)
+                    lastActivityMs.set(SystemClock.elapsedRealtime())
+                    firstTokenSeen.set(true)
+                    onToken(rawBuilder.toString())
+                    // Hard output cap (length): a runaway that never emits a stop would stream
+                    // forever. Interrupt native generation and throw to unwind the collect now.
+                    if (++tokenCount >= MAX_OUTPUT_TOKENS) {
+                        capReached = true
+                        Log.w(TAG, "Output cap reached ($tokenCount tokens) — stopping generation")
+                        try { conv.cancelProcess() } catch (_: Exception) {}
+                        throw OutputCapReached()
+                    }
+                }
+            } catch (e: OutputCapReached) {
+                // Cap hit — collectJob completes normally; capReached drives the failure below.
+            }
+        }
+
+        // Watchdog (time): trips on a too-long prefill (no first token yet), an inter-token stall,
+        // or the absolute wall-clock ceiling. It records WHY, signals native to stop, and cancels
+        // the collect. Runs on Default so a busy IO thread can't starve the deadline checks.
+        val watchdog = launch(Dispatchers.Default) {
+            while (isActive) {
+                delay(WATCHDOG_TICK_MS)
+                val now = SystemClock.elapsedRealtime()
+                val started = firstTokenSeen.get()
+                val tripped = when {
+                    now - startMs >= TOTAL_BUDGET_MS -> TimeoutKind.TOTAL
+                    now - lastActivityMs.get() >=
+                        (if (started) INACTIVITY_BUDGET_MS else PREFILL_BUDGET_MS) ->
+                        if (started) TimeoutKind.STALL else TimeoutKind.PREFILL
+                    else -> null
+                }
+                if (tripped != null) {
+                    timeoutKind.set(tripped)
+                    Log.w(TAG, "watchdog: $tripped budget exceeded — stopping generation")
+                    try { conv.cancelProcess() } catch (_: Exception) {}
+                    collectJob.cancel()
+                    break
+                }
+            }
+        }
+
+        // join() returns whether the collect finished normally, hit the cap, or was cancelled by
+        // the watchdog (a cancelled child does not fail the scope). Genuine user/background
+        // cancellation cancels this whole coroutineScope instead, propagating a CancellationException
+        // out of runInference — handled as before by solveFromImageStreaming.
+        collectJob.join()
+        watchdog.cancel()
+
+        // Only a watchdog-cancelled collect is a real timeout. Guarding on isCancelled avoids a race
+        // where the watchdog trips in the sliver between a NORMAL completion and watchdog.cancel(),
+        // which would otherwise flip a successful (but slow, >TOTAL_BUDGET) scan into a failure.
+        if (collectJob.isCancelled) {
+            val kind = timeoutKind.get() ?: TimeoutKind.TOTAL
+            return@coroutineScope Result.failure(
+                RecognitionException(kind.message, rawBuilder.toString(), kind.messageRes))
+        }
+        if (capReached) {
+            return@coroutineScope Result.failure(
+                RecognitionException(
+                    "The answer was cut off before the model finished — it ran past the length " +
+                        "limit. Please try again.",
+                    rawBuilder.toString(),
+                    R.string.error_output_cut_off
+                )
             )
-        ).collect { message ->
-            val text = message.contents.contents
-                .filterIsInstance<Content.Text>()
-                .joinToString("") { it.text }
-            rawBuilder.append(text)
-            onToken(rawBuilder.toString())
         }
         val raw = rawBuilder.toString()
         val answer = SolverPrompts.extractAnswer(raw)
-        return if (answer.isBlank()) {
+        if (answer.isBlank()) {
             Result.failure(RecognitionException(
                 "Could not extract a numerical answer", raw, R.string.error_no_numerical_answer))
         } else {
@@ -185,6 +272,46 @@ class LiteRTSolver : MathSolver {
 
     companion object {
         private const val TAG = "LiteRTSolver"
+
+        /** Internal signal thrown to unwind token streaming the moment the output cap is hit. */
+        private class OutputCapReached : Exception()
+
+        /**
+         * Hard ceiling on generated chunks (≈ tokens) per scan — a safety net against a runaway
+         * generation that never emits a stop (it would otherwise stream forever and pin the GPU).
+         * Deliberately set well ABOVE any legitimate answer so it never truncates a hard question:
+         * a math solution with steps is a few hundred tokens at most, and this is near the model's
+         * own KV-cache ceiling. Because it's a token (not time) cap, it cuts off at the same amount
+         * of content regardless of device speed — a fast phone just reaches it sooner in wall-time.
+         * Tune here if answers ever get truncated.
+         */
+        private const val MAX_OUTPUT_TOKENS = 2048
+
+        /** Why the watchdog aborted a generation. [message] is the English fallback; [messageRes]
+         *  is the localized string the UI resolves (the solver has no Context). */
+        private enum class TimeoutKind(val message: String, @StringRes val messageRes: Int) {
+            PREFILL("The model got stuck before producing an answer. Please try again.",
+                R.string.error_prefill_timeout),
+            STALL("The answer stopped midway through. Please try again.",
+                R.string.error_stall_timeout),
+            TOTAL("The scan took too long and was stopped. Please try again with a clearer photo.",
+                R.string.error_total_timeout),
+        }
+
+        /** First-token (prefill) budget. Vision prefill is long — ~25s+ on a Galaxy Note 9 — so it
+         *  gets its own generous allowance, separate from inter-token stalls. */
+        private const val PREFILL_BUDGET_MS = 60_000L
+
+        /** Max gap between two decoded tokens once decoding has started. Decode runs ~2–10 tok/s
+         *  (gaps of 100–500ms), so 20s only trips on a genuine native stall, not slow-but-alive. */
+        private const val INACTIVITY_BUDGET_MS = 20_000L
+
+        /** Absolute wall-clock ceiling for one generation (prefill + decode). Bounds the
+         *  pathological case; a healthy math answer finishes well inside this. */
+        private const val TOTAL_BUDGET_MS = 120_000L
+
+        /** How often the watchdog re-evaluates the deadlines. */
+        private const val WATCHDOG_TICK_MS = 1_000L
 
         /** Wrap [Throwable] in an [Exception] so callers expecting Exception types are satisfied. */
         private fun Throwable.asException(): Exception =

--- a/app/src/main/java/com/vagujhelyigergely/calculatorm3/camera/CameraScanScreen.kt
+++ b/app/src/main/java/com/vagujhelyigergely/calculatorm3/camera/CameraScanScreen.kt
@@ -3,15 +3,20 @@
 package com.vagujhelyigergely.calculatorm3.camera
 
 import android.Manifest
+import android.content.Context
+import android.content.ContextWrapper
 import android.content.Intent
 import android.content.pm.PackageManager
 import android.content.res.Configuration
 import android.net.Uri
 import android.os.Build
 import android.widget.TextView
+import androidx.activity.ComponentActivity
 import androidx.activity.compose.rememberLauncherForActivityResult
 import androidx.activity.result.PickVisualMediaRequest
 import androidx.activity.result.contract.ActivityResultContracts
+import androidx.lifecycle.Lifecycle
+import androidx.lifecycle.LifecycleEventObserver
 import androidx.core.content.ContextCompat
 import androidx.core.content.FileProvider
 import androidx.compose.ui.platform.LocalConfiguration
@@ -57,6 +62,7 @@ import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.graphicsLayer
 import androidx.compose.ui.graphics.vector.ImageVector
+import android.util.Log
 import android.view.WindowManager
 import androidx.compose.ui.hapticfeedback.HapticFeedbackType
 import androidx.compose.ui.input.nestedscroll.nestedScroll
@@ -177,6 +183,30 @@ fun CameraScanScreen(
         onDispose {
             activity?.window?.clearFlags(WindowManager.LayoutParams.FLAG_KEEP_SCREEN_ON)
         }
+    }
+
+    // Stop inference when the app is genuinely backgrounded (Home / app-switch) so generation and
+    // the GPU engine don't keep running off-screen and drain the battery while forgotten. Guarded
+    // by isChangingConfigurations: a rotation also fires ON_STOP, and stopping there would undo the
+    // rotation state-preservation. Inference only starts once the Activity is RESUMED again, so an
+    // ON_STOP during a scan is always a real background, never the camera/gallery round-trip.
+    // Unwrap the context to find the hosting ComponentActivity. A direct cast can be null when the
+    // Compose context is a ContextWrapper (e.g. ContextThemeWrapper), which would silently disable
+    // this safeguard, so walk the wrapper chain instead.
+    val lifecycleActivity = remember(context) {
+        var ctx: Context? = context
+        while (ctx is ContextWrapper && ctx !is ComponentActivity) ctx = ctx.baseContext
+        ctx as? ComponentActivity
+    }
+    DisposableEffect(lifecycleActivity) {
+        val observer = LifecycleEventObserver { _, event ->
+            if (event == Lifecycle.Event.ON_STOP && lifecycleActivity?.isChangingConfigurations == false) {
+                Log.i("CameraScanScreen", "background ON_STOP -> stopInference")
+                viewModel.stopInference()
+            }
+        }
+        lifecycleActivity?.lifecycle?.addObserver(observer)
+        onDispose { lifecycleActivity?.lifecycle?.removeObserver(observer) }
     }
 
     Dialog(

--- a/app/src/main/res/values-de/strings.xml
+++ b/app/src/main/res/values-de/strings.xml
@@ -98,4 +98,8 @@
     <string name="error_image_process">Dieses Bild konnte nicht verarbeitet werden. Bitte versuche ein anderes Foto.</string>
     <string name="error_inference_failed">Inferenz fehlgeschlagen: %1$s</string>
     <string name="error_capture_failed">Aufnahme fehlgeschlagen: %1$s</string>
+    <string name="error_output_cut_off">Die Antwort wurde abgeschnitten, bevor das Modell fertig war — sie hat die Längengrenze überschritten. Bitte versuche es erneut.</string>
+    <string name="error_prefill_timeout">Das Modell ist hängengeblieben, bevor es eine Antwort erzeugt hat. Bitte versuche es erneut.</string>
+    <string name="error_stall_timeout">Die Antwort wurde mittendrin abgebrochen. Bitte versuche es erneut.</string>
+    <string name="error_total_timeout">Der Scan hat zu lange gedauert und wurde gestoppt. Bitte versuche es mit einem schärferen Foto.</string>
 </resources>

--- a/app/src/main/res/values-es/strings.xml
+++ b/app/src/main/res/values-es/strings.xml
@@ -98,4 +98,8 @@
     <string name="error_image_process">No se pudo procesar esa imagen. Prueba con otra foto.</string>
     <string name="error_inference_failed">Error de inferencia: %1$s</string>
     <string name="error_capture_failed">Error al capturar: %1$s</string>
+    <string name="error_output_cut_off">La respuesta se cortó antes de que el modelo terminara: superó el límite de longitud. Inténtalo de nuevo.</string>
+    <string name="error_prefill_timeout">El modelo se quedó atascado antes de producir una respuesta. Inténtalo de nuevo.</string>
+    <string name="error_stall_timeout">La respuesta se detuvo a mitad. Inténtalo de nuevo.</string>
+    <string name="error_total_timeout">El escaneo tardó demasiado y se detuvo. Prueba con una foto más nítida.</string>
 </resources>

--- a/app/src/main/res/values-fr/strings.xml
+++ b/app/src/main/res/values-fr/strings.xml
@@ -98,4 +98,8 @@
     <string name="error_image_process">Impossible de traiter cette image. Veuillez essayer une autre photo.</string>
     <string name="error_inference_failed">Échec de l\'inférence : %1$s</string>
     <string name="error_capture_failed">Échec de la capture : %1$s</string>
+    <string name="error_output_cut_off">La réponse a été coupée avant que le modèle ait terminé : elle a dépassé la limite de longueur. Veuillez réessayer.</string>
+    <string name="error_prefill_timeout">Le modèle s\'est bloqué avant de produire une réponse. Veuillez réessayer.</string>
+    <string name="error_stall_timeout">La réponse s\'est interrompue en cours. Veuillez réessayer.</string>
+    <string name="error_total_timeout">L\'analyse a pris trop de temps et a été arrêtée. Veuillez essayer une photo plus nette.</string>
 </resources>

--- a/app/src/main/res/values-hi/strings.xml
+++ b/app/src/main/res/values-hi/strings.xml
@@ -98,4 +98,8 @@
     <string name="error_image_process">वह छवि संसाधित नहीं हो सकी। कृपया कोई दूसरी फ़ोटो आज़माएँ।</string>
     <string name="error_inference_failed">अनुमान विफल: %1$s</string>
     <string name="error_capture_failed">कैप्चर विफल: %1$s</string>
+    <string name="error_output_cut_off">मॉडल के पूरा होने से पहले उत्तर कट गया — यह लंबाई सीमा से आगे चला गया। कृपया पुनः प्रयास करें।</string>
+    <string name="error_prefill_timeout">उत्तर देने से पहले मॉडल अटक गया। कृपया पुनः प्रयास करें।</string>
+    <string name="error_stall_timeout">उत्तर बीच में ही रुक गया। कृपया पुनः प्रयास करें।</string>
+    <string name="error_total_timeout">स्कैन में बहुत अधिक समय लगा और रोक दिया गया। कृपया अधिक स्पष्ट फ़ोटो आज़माएँ।</string>
 </resources>

--- a/app/src/main/res/values-hu/strings.xml
+++ b/app/src/main/res/values-hu/strings.xml
@@ -98,4 +98,8 @@
     <string name="error_image_process">Nem sikerült feldolgozni a képet. Próbálj meg egy másik fotót.</string>
     <string name="error_inference_failed">A következtetés sikertelen: %1$s</string>
     <string name="error_capture_failed">A rögzítés sikertelen: %1$s</string>
+    <string name="error_output_cut_off">A válasz megszakadt, mielőtt a modell befejezte volna — túllépte a hosszúsági korlátot. Kérjük, próbáld újra.</string>
+    <string name="error_prefill_timeout">A modell elakadt, mielőtt választ adott volna. Kérjük, próbáld újra.</string>
+    <string name="error_stall_timeout">A válasz félúton megszakadt. Kérjük, próbáld újra.</string>
+    <string name="error_total_timeout">A beolvasás túl sokáig tartott, ezért leállt. Próbálj meg egy élesebb fotót.</string>
 </resources>

--- a/app/src/main/res/values-in/strings.xml
+++ b/app/src/main/res/values-in/strings.xml
@@ -97,4 +97,8 @@
     <string name="error_image_process">Tidak dapat memproses gambar itu. Coba foto lain.</string>
     <string name="error_inference_failed">Inferensi gagal: %1$s</string>
     <string name="error_capture_failed">Gagal mengambil gambar: %1$s</string>
+    <string name="error_output_cut_off">Jawaban terpotong sebelum model selesai — melebihi batas panjang. Silakan coba lagi.</string>
+    <string name="error_prefill_timeout">Model macet sebelum menghasilkan jawaban. Silakan coba lagi.</string>
+    <string name="error_stall_timeout">Jawaban berhenti di tengah jalan. Silakan coba lagi.</string>
+    <string name="error_total_timeout">Pemindaian terlalu lama dan dihentikan. Coba foto yang lebih jelas.</string>
 </resources>

--- a/app/src/main/res/values-it/strings.xml
+++ b/app/src/main/res/values-it/strings.xml
@@ -98,4 +98,8 @@
     <string name="error_image_process">Impossibile elaborare l\'immagine. Prova un\'altra foto.</string>
     <string name="error_inference_failed">Inferenza non riuscita: %1$s</string>
     <string name="error_capture_failed">Acquisizione non riuscita: %1$s</string>
+    <string name="error_output_cut_off">La risposta è stata interrotta prima che il modello finisse: ha superato il limite di lunghezza. Riprova.</string>
+    <string name="error_prefill_timeout">Il modello si è bloccato prima di produrre una risposta. Riprova.</string>
+    <string name="error_stall_timeout">La risposta si è interrotta a metà. Riprova.</string>
+    <string name="error_total_timeout">La scansione ha richiesto troppo tempo ed è stata interrotta. Prova con una foto più nitida.</string>
 </resources>

--- a/app/src/main/res/values-ja/strings.xml
+++ b/app/src/main/res/values-ja/strings.xml
@@ -97,4 +97,8 @@
     <string name="error_image_process">その画像を処理できませんでした。別の写真でお試しください。</string>
     <string name="error_inference_failed">推論に失敗しました: %1$s</string>
     <string name="error_capture_failed">撮影に失敗しました: %1$s</string>
+    <string name="error_output_cut_off">モデルが完了する前に回答が途切れました。文字数の上限を超えています。もう一度お試しください。</string>
+    <string name="error_prefill_timeout">回答を生成する前にモデルが停止しました。もう一度お試しください。</string>
+    <string name="error_stall_timeout">回答が途中で止まりました。もう一度お試しください。</string>
+    <string name="error_total_timeout">スキャンに時間がかかりすぎたため停止しました。より鮮明な写真でお試しください。</string>
 </resources>

--- a/app/src/main/res/values-ko/strings.xml
+++ b/app/src/main/res/values-ko/strings.xml
@@ -97,4 +97,8 @@
     <string name="error_image_process">이미지를 처리할 수 없습니다. 다른 사진을 사용해 보세요.</string>
     <string name="error_inference_failed">추론 실패: %1$s</string>
     <string name="error_capture_failed">촬영 실패: %1$s</string>
+    <string name="error_output_cut_off">모델이 완료되기 전에 답변이 잘렸습니다. 길이 제한을 초과했습니다. 다시 시도해 주세요.</string>
+    <string name="error_prefill_timeout">답변을 생성하기 전에 모델이 멈췄습니다. 다시 시도해 주세요.</string>
+    <string name="error_stall_timeout">답변이 중간에 멈췄습니다. 다시 시도해 주세요.</string>
+    <string name="error_total_timeout">스캔이 너무 오래 걸려 중지되었습니다. 더 선명한 사진으로 다시 시도해 주세요.</string>
 </resources>

--- a/app/src/main/res/values-nl/strings.xml
+++ b/app/src/main/res/values-nl/strings.xml
@@ -98,4 +98,8 @@
     <string name="error_image_process">Kan die afbeelding niet verwerken. Probeer een andere foto.</string>
     <string name="error_inference_failed">Inferentie mislukt: %1$s</string>
     <string name="error_capture_failed">Vastleggen mislukt: %1$s</string>
+    <string name="error_output_cut_off">Het antwoord werd afgebroken voordat het model klaar was — het overschreed de lengtelimiet. Probeer het opnieuw.</string>
+    <string name="error_prefill_timeout">Het model liep vast voordat het een antwoord gaf. Probeer het opnieuw.</string>
+    <string name="error_stall_timeout">Het antwoord stopte halverwege. Probeer het opnieuw.</string>
+    <string name="error_total_timeout">Het scannen duurde te lang en is gestopt. Probeer een scherpere foto.</string>
 </resources>

--- a/app/src/main/res/values-pl/strings.xml
+++ b/app/src/main/res/values-pl/strings.xml
@@ -100,4 +100,8 @@
     <string name="error_image_process">Nie udało się przetworzyć tego zdjęcia. Spróbuj innego.</string>
     <string name="error_inference_failed">Wnioskowanie nie powiodło się: %1$s</string>
     <string name="error_capture_failed">Przechwytywanie nie powiodło się: %1$s</string>
+    <string name="error_output_cut_off">Odpowiedź została ucięta, zanim model zakończył — przekroczyła limit długości. Spróbuj ponownie.</string>
+    <string name="error_prefill_timeout">Model zaciął się przed wygenerowaniem odpowiedzi. Spróbuj ponownie.</string>
+    <string name="error_stall_timeout">Odpowiedź zatrzymała się w połowie. Spróbuj ponownie.</string>
+    <string name="error_total_timeout">Skanowanie trwało zbyt długo i zostało zatrzymane. Spróbuj wyraźniejszego zdjęcia.</string>
 </resources>

--- a/app/src/main/res/values-pt-rBR/strings.xml
+++ b/app/src/main/res/values-pt-rBR/strings.xml
@@ -98,4 +98,8 @@
     <string name="error_image_process">Não foi possível processar essa imagem. Tente outra foto.</string>
     <string name="error_inference_failed">Falha na inferência: %1$s</string>
     <string name="error_capture_failed">Falha na captura: %1$s</string>
+    <string name="error_output_cut_off">A resposta foi cortada antes de o modelo terminar — ultrapassou o limite de comprimento. Tente novamente.</string>
+    <string name="error_prefill_timeout">O modelo travou antes de produzir uma resposta. Tente novamente.</string>
+    <string name="error_stall_timeout">A resposta parou no meio. Tente novamente.</string>
+    <string name="error_total_timeout">A leitura demorou muito e foi interrompida. Tente uma foto mais nítida.</string>
 </resources>

--- a/app/src/main/res/values-ru/strings.xml
+++ b/app/src/main/res/values-ru/strings.xml
@@ -100,4 +100,8 @@
     <string name="error_image_process">Не удалось обработать это изображение. Попробуйте другое фото.</string>
     <string name="error_inference_failed">Ошибка вывода: %1$s</string>
     <string name="error_capture_failed">Не удалось сделать снимок: %1$s</string>
+    <string name="error_output_cut_off">Ответ был обрезан до завершения модели — превышен предел длины. Попробуйте ещё раз.</string>
+    <string name="error_prefill_timeout">Модель зависла, не успев дать ответ. Попробуйте ещё раз.</string>
+    <string name="error_stall_timeout">Ответ прервался на середине. Попробуйте ещё раз.</string>
+    <string name="error_total_timeout">Сканирование заняло слишком много времени и было остановлено. Попробуйте более чёткое фото.</string>
 </resources>

--- a/app/src/main/res/values-tr/strings.xml
+++ b/app/src/main/res/values-tr/strings.xml
@@ -98,4 +98,8 @@
     <string name="error_image_process">Bu görüntü işlenemedi. Lütfen başka bir fotoğraf deneyin.</string>
     <string name="error_inference_failed">Çıkarım başarısız: %1$s</string>
     <string name="error_capture_failed">Yakalama başarısız: %1$s</string>
+    <string name="error_output_cut_off">Yanıt, model bitirmeden kesildi — uzunluk sınırını aştı. Lütfen tekrar deneyin.</string>
+    <string name="error_prefill_timeout">Model, yanıt üretmeden takıldı. Lütfen tekrar deneyin.</string>
+    <string name="error_stall_timeout">Yanıt yarıda durdu. Lütfen tekrar deneyin.</string>
+    <string name="error_total_timeout">Tarama çok uzun sürdü ve durduruldu. Lütfen daha net bir fotoğraf deneyin.</string>
 </resources>

--- a/app/src/main/res/values-uk/strings.xml
+++ b/app/src/main/res/values-uk/strings.xml
@@ -100,4 +100,8 @@
     <string name="error_image_process">Не вдалося обробити це зображення. Спробуйте інше фото.</string>
     <string name="error_inference_failed">Помилка висновку: %1$s</string>
     <string name="error_capture_failed">Не вдалося зробити знімок: %1$s</string>
+    <string name="error_output_cut_off">Відповідь обірвалася до завершення моделі — перевищено обмеження довжини. Повторіть спробу.</string>
+    <string name="error_prefill_timeout">Модель зависла, не встигнувши дати відповідь. Повторіть спробу.</string>
+    <string name="error_stall_timeout">Відповідь зупинилася на середині. Повторіть спробу.</string>
+    <string name="error_total_timeout">Сканування тривало надто довго й було зупинено. Спробуйте чіткіше фото.</string>
 </resources>

--- a/app/src/main/res/values-vi/strings.xml
+++ b/app/src/main/res/values-vi/strings.xml
@@ -97,4 +97,8 @@
     <string name="error_image_process">Không thể xử lý ảnh đó. Vui lòng thử ảnh khác.</string>
     <string name="error_inference_failed">Suy luận thất bại: %1$s</string>
     <string name="error_capture_failed">Chụp thất bại: %1$s</string>
+    <string name="error_output_cut_off">Câu trả lời bị cắt trước khi mô hình hoàn tất — đã vượt quá giới hạn độ dài. Vui lòng thử lại.</string>
+    <string name="error_prefill_timeout">Mô hình bị kẹt trước khi đưa ra câu trả lời. Vui lòng thử lại.</string>
+    <string name="error_stall_timeout">Câu trả lời dừng lại giữa chừng. Vui lòng thử lại.</string>
+    <string name="error_total_timeout">Quá trình quét mất quá nhiều thời gian và đã dừng. Vui lòng thử ảnh rõ hơn.</string>
 </resources>

--- a/app/src/main/res/values-zh-rCN/strings.xml
+++ b/app/src/main/res/values-zh-rCN/strings.xml
@@ -97,4 +97,8 @@
     <string name="error_image_process">无法处理该图片。请尝试其他照片。</string>
     <string name="error_inference_failed">推理失败：%1$s</string>
     <string name="error_capture_failed">拍摄失败：%1$s</string>
+    <string name="error_output_cut_off">回答在模型完成前被截断——超出了长度限制。请重试。</string>
+    <string name="error_prefill_timeout">模型在给出回答前卡住了。请重试。</string>
+    <string name="error_stall_timeout">回答中途停止了。请重试。</string>
+    <string name="error_total_timeout">扫描耗时过长，已停止。请尝试更清晰的照片。</string>
 </resources>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -54,6 +54,10 @@
     <string name="error_image_process">Couldn\'t process that image. Please try another photo.</string>
     <string name="error_inference_failed">Inference failed: %1$s</string>
     <string name="error_capture_failed">Capture failed: %1$s</string>
+    <string name="error_output_cut_off">The answer was cut off before the model finished — it ran past the length limit. Please try again.</string>
+    <string name="error_prefill_timeout">The model got stuck before producing an answer. Please try again.</string>
+    <string name="error_stall_timeout">The answer stopped midway through. Please try again.</string>
+    <string name="error_total_timeout">The scan took too long and was stopped. Please try again with a clearer photo.</string>
     <string name="choose_model">Choose AI model</string>
     <string name="choose_model_description">Your device has %1$d GB RAM. Larger models are more accurate but slower. All models run entirely on your device.</string>
     <string name="model_too_large">Needs %1$d GB RAM — your device has %2$d GB</string>


### PR DESCRIPTION
Re-targets the **generation safeguards** at `develop`.

PR #76 carried these changes but was merged into its *stacked base* (`fix/localize-ai-scan-errors`, the #77 i18n branch) — ~30s after #77 had already merged into `develop` — so the safeguards never actually landed on `develop`. This brings them in cleanly (cherry-picked onto current develop; the i18n mechanism from #77 is already present, so it integrates without duplication).

Contents (same as the reviewed-and-approved #76):
- **Output-token cap** (2048) + **timeout watchdog** (prefill / inactivity / total) + **background-stop** (ON_STOP, guarded by `isChangingConfigurations`).
- Bot-review fixes folded in: recursive `ContextWrapper` unwrap for the activity, and `collectJob.isCancelled` guard against the watchdog race.
- The 4 safeguard messages are **localized into all 17 locales** (using #77's `messageRes` mechanism, now on develop).

Verified on a Galaxy Note 9 earlier (prefill timeout fires cleanly with no hang/CPU-fallback; background-stop frees the GPU in-flight within 0.25s; rotation does not stop it; normal scan unaffected). Builds clean on top of develop.
